### PR TITLE
Use ARC V2 self-hosted runners for CPU jobs

### DIFF
--- a/.github/workflows/build-and-push-image.yml
+++ b/.github/workflows/build-and-push-image.yml
@@ -26,7 +26,7 @@ jobs:
 
   build-and-push:
     name: Build and push to ghcr.io
-    runs-on: ${{ fromJSON(github.repository != 'rapidsai/devcontainers' && '"ubuntu-latest"' || format('{{"labels":["self-hosted", "linux", "{0}", "cpu4"]}}', matrix.arch)) }}
+    runs-on: ${{ fromJSON(github.repository != 'rapidsai/devcontainers' && '"ubuntu-latest"' || format('"linux-{0}-cpu4"', matrix.arch)) }}
     permissions:
       packages: write
     outputs:

--- a/.github/workflows/build-and-test-feature.yml
+++ b/.github/workflows/build-and-test-feature.yml
@@ -14,7 +14,7 @@ jobs:
 
   test:
     name: ${{ inputs.name }} (${{ matrix.arch }})
-    runs-on: ${{ fromJSON(github.repository != 'rapidsai/devcontainers' && '"ubuntu-latest"' || format('{{"labels":["self-hosted", "linux", "{0}", "cpu4"]}}', matrix.arch)) }}
+    runs-on: ${{ fromJSON(github.repository != 'rapidsai/devcontainers' && '"ubuntu-latest"' || format('"linux-{0}-cpu4"', matrix.arch)) }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-and-test-image.yml
+++ b/.github/workflows/build-and-test-image.yml
@@ -26,7 +26,7 @@ jobs:
 
   build-and-test:
     name: Build and test
-    runs-on: ${{ fromJSON(github.repository != 'rapidsai/devcontainers' && '"ubuntu-latest"' || format('{{"labels":["self-hosted", "linux", "{0}", "cpu4"]}}', matrix.arch)) }}
+    runs-on: ${{ fromJSON(github.repository != 'rapidsai/devcontainers' && '"ubuntu-latest"' || format('"linux-{0}-cpu4"', matrix.arch)) }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
This PR is updating the runner labels to use ARC V2 self-hosted runners for CPU jobs only. This is needed to resolve the auto-scalling issues.