### PR TITLE
Define vars in `containerEnv` so they're visible to downstream feature layers

### DIFF
--- a/features/src/cuda/devcontainer-feature.json
+++ b/features/src/cuda/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "CUDA Toolkit",
   "id": "cuda",
-  "version": "23.6.3",
+  "version": "23.6.4",
   "description": "A feature to install the NVIDIA CUDA Toolkit",
   "options": {
     "version": {
@@ -27,8 +27,13 @@
     }
   },
   "containerEnv": {
+    "BASH_ENV": "/etc/bash.bash_env",
+    "CUDA_HOME": "/usr/local/cuda",
     "NVIDIA_VISIBLE_DEVICES": "all",
-    "NVIDIA_DRIVER_CAPABILITIES": "all"
+    "NVIDIA_DRIVER_CAPABILITIES": "all",
+    "PATH": "/usr/local/nvidia/bin:${CUDA_HOME}/bin:${PATH}",
+    "LIBRARY_PATH": "${CUDA_HOME}/lib64/stubs",
+    "LD_LIBRARY_PATH": "/usr/local/nvidia/lib:/usr/local/nvidia/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
   },
   "capAdd": [
     "SYS_PTRACE"

--- a/features/src/cuda/devcontainer-feature.json
+++ b/features/src/cuda/devcontainer-feature.json
@@ -28,12 +28,8 @@
   },
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env",
-    "CUDA_HOME": "/usr/local/cuda",
     "NVIDIA_VISIBLE_DEVICES": "all",
-    "NVIDIA_DRIVER_CAPABILITIES": "all",
-    "PATH": "/usr/local/nvidia/bin:${CUDA_HOME}/bin:${PATH}",
-    "LIBRARY_PATH": "${CUDA_HOME}/lib64/stubs",
-    "LD_LIBRARY_PATH": "/usr/local/nvidia/lib:/usr/local/nvidia/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    "NVIDIA_DRIVER_CAPABILITIES": "all"
   },
   "capAdd": [
     "SYS_PTRACE"

--- a/features/src/llvm/devcontainer-feature.json
+++ b/features/src/llvm/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "LLVM compilers and tools",
   "id": "llvm",
-  "version": "23.6.2",
+  "version": "23.6.3",
   "description": "A feature to install LLVM compilers and tools",
   "options": {
     "version": {
@@ -21,6 +21,9 @@
       "default": "dev",
       "description": "LLVM version to install."
     }
+  },
+  "containerEnv": {
+    "BASH_ENV": "/etc/bash.bash_env"
   },
   "capAdd": [
     "SYS_PTRACE"

--- a/features/src/mambaforge/devcontainer-feature.json
+++ b/features/src/mambaforge/devcontainer-feature.json
@@ -16,9 +16,7 @@
     }
   },
   "containerEnv": {
-    "MAMBA_NO_BANNER": "1",
-    "BASH_ENV": "/etc/bash.bash_env",
-    "PATH": "${PATH}:/opt/conda/bin"
+    "BASH_ENV": "/etc/bash.bash_env"
   },
   "customizations": {
     "vscode": {

--- a/features/src/mambaforge/devcontainer-feature.json
+++ b/features/src/mambaforge/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Mambaforge",
   "id": "mambaforge",
-  "version": "23.6.1",
+  "version": "23.6.2",
   "description": "A feature to install mambaforge",
   "options": {
     "version": {
@@ -14,6 +14,11 @@
       "default": "latest",
       "description": "Mambaforge version to install."
     }
+  },
+  "containerEnv": {
+    "MAMBA_NO_BANNER": "1",
+    "BASH_ENV": "/etc/bash.bash_env",
+    "PATH": "${PATH}:/opt/conda/bin"
   },
   "customizations": {
     "vscode": {

--- a/features/src/nvhpc/devcontainer-feature.json
+++ b/features/src/nvhpc/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVHPC SDK",
   "id": "nvhpc",
-  "version": "23.6.2",
+  "version": "23.6.3",
   "description": "A feature to install the NVHPC SDK",
   "options": {
     "version": {
@@ -15,6 +15,9 @@
       "default": "23.1",
       "description": "Version of NVHPC SDK to install."
     }
+  },
+  "containerEnv": {
+    "BASH_ENV": "/etc/bash.bash_env"
   },
   "capAdd": [
     "SYS_PTRACE"

--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,8 +1,12 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "23.6.3",
+  "version": "23.6.4",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
+  "containerEnv": {
+    "CONDA_ALWAYS_YES": "true",
+    "BASH_ENV": "/etc/bash.bash_env"
+  },
   "updateContentCommand": [
     "/bin/bash",
     "-li",

--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -4,7 +4,6 @@
   "version": "23.6.4",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
-    "CONDA_ALWAYS_YES": "true",
     "BASH_ENV": "/etc/bash.bash_env"
   },
   "updateContentCommand": [

--- a/features/src/rust/devcontainer-feature.json
+++ b/features/src/rust/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "rust",
-  "version": "23.6.1",
+  "version": "23.6.2",
   "name": "Rust",
   "documentationURL": "https://github.com/rapidsai/devcontainers/features/tree/main/src/rust",
   "description": "Installs Rust, common Rust utilities, and their required dependencies",
@@ -35,6 +35,11 @@
       "type": "boolean",
       "default": false
     }
+  },
+  "containerEnv": {
+    "CARGO_HOME": "/usr/local/cargo",
+    "RUSTUP_HOME": "/usr/local/rustup",
+    "PATH": "/usr/local/cargo/bin:${PATH}"
   },
   "capAdd": [
     "SYS_PTRACE"

--- a/features/src/rust/devcontainer-feature.json
+++ b/features/src/rust/devcontainer-feature.json
@@ -37,9 +37,7 @@
     }
   },
   "containerEnv": {
-    "CARGO_HOME": "/usr/local/cargo",
-    "RUSTUP_HOME": "/usr/local/rustup",
-    "PATH": "/usr/local/cargo/bin:${PATH}"
+    "BASH_ENV": "/etc/bash.bash_env"
   },
   "capAdd": [
     "SYS_PTRACE"

--- a/features/src/sccache/devcontainer-feature.json
+++ b/features/src/sccache/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "sccache",
   "id": "sccache",
-  "version": "23.6.1",
+  "version": "23.6.2",
   "description": "A feature to install sccache",
   "options": {
     "version": {
@@ -16,5 +16,12 @@
       "default": "latest",
       "description": "sccache version to install."
     }
+  },
+  "containerEnv": {
+    "SCCACHE_IDLE_TIMEOUT": "32768",
+    "RUSTC_WRAPPER": "/usr/bin/sccache",
+    "CMAKE_C_COMPILER_LAUNCHER": "/usr/bin/sccache",
+    "CMAKE_CXX_COMPILER_LAUNCHER": "/usr/bin/sccache",
+    "CMAKE_CUDA_COMPILER_LAUNCHER": "/usr/bin/sccache"
   }
 }

--- a/features/src/sccache/devcontainer-feature.json
+++ b/features/src/sccache/devcontainer-feature.json
@@ -18,10 +18,6 @@
     }
   },
   "containerEnv": {
-    "SCCACHE_IDLE_TIMEOUT": "32768",
-    "RUSTC_WRAPPER": "/usr/bin/sccache",
-    "CMAKE_C_COMPILER_LAUNCHER": "/usr/bin/sccache",
-    "CMAKE_CXX_COMPILER_LAUNCHER": "/usr/bin/sccache",
-    "CMAKE_CUDA_COMPILER_LAUNCHER": "/usr/bin/sccache"
+    "BASH_ENV": "/etc/bash.bash_env"
   }
 }

--- a/features/src/utils/devcontainer-feature.json
+++ b/features/src/utils/devcontainer-feature.json
@@ -1,8 +1,11 @@
 {
   "name": "devcontainer utils",
   "id": "utils",
-  "version": "23.6.1",
+  "version": "23.6.2",
   "description": "A feature to install my devcontainer utilities",
+  "containerEnv": {
+    "BASH_ENV": "/etc/bash.bash_env"
+  },
   "postAttachCommand": [
     "/bin/bash",
     "-li",


### PR DESCRIPTION
Follow up to fix an issue in #69.

Define the BASH_ENV var in the devcontainer-feature.json's `"containerEnv"` so it's embedded into the Dockerfile. This ensures the `/etc/bash.bash_env` file is sourced for shells at build time, running any previous feature's startup scripts.