### PR TITLE
remove `/etc/profile.d/00-restore-env.sh`

### DIFF
--- a/features/common/install.sh
+++ b/features/common/install.sh
@@ -26,11 +26,6 @@ export BASH_ENV=/etc/bash.bash_env;
 EOF
 )";
 
-# Ensure that login shells get the correct path if the user updated the PATH using ENV.
-rm -f /etc/profile.d/00-restore-env.sh
-echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
-chmod +x /etc/profile.d/00-restore-env.sh
-
 if ! grep -qE '^BASH_ENV=/etc/bash.bash_env$' /etc/environment; then
     echo "BASH_ENV=/etc/bash.bash_env" >> /etc/environment;
 fi

--- a/features/src/cmake/common/install.sh
+++ b/features/src/cmake/common/install.sh
@@ -26,11 +26,6 @@ export BASH_ENV=/etc/bash.bash_env;
 EOF
 )";
 
-# Ensure that login shells get the correct path if the user updated the PATH using ENV.
-rm -f /etc/profile.d/00-restore-env.sh
-echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
-chmod +x /etc/profile.d/00-restore-env.sh
-
 if ! grep -qE '^BASH_ENV=/etc/bash.bash_env$' /etc/environment; then
     echo "BASH_ENV=/etc/bash.bash_env" >> /etc/environment;
 fi

--- a/features/src/cmake/devcontainer-feature.json
+++ b/features/src/cmake/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "CMake",
   "id": "cmake",
-  "version": "23.8.0",
+  "version": "23.8.1",
   "description": "A feature to install CMake",
   "options": {
     "version": {

--- a/features/src/cuda/common/install.sh
+++ b/features/src/cuda/common/install.sh
@@ -26,11 +26,6 @@ export BASH_ENV=/etc/bash.bash_env;
 EOF
 )";
 
-# Ensure that login shells get the correct path if the user updated the PATH using ENV.
-rm -f /etc/profile.d/00-restore-env.sh
-echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
-chmod +x /etc/profile.d/00-restore-env.sh
-
 if ! grep -qE '^BASH_ENV=/etc/bash.bash_env$' /etc/environment; then
     echo "BASH_ENV=/etc/bash.bash_env" >> /etc/environment;
 fi

--- a/features/src/cuda/devcontainer-feature.json
+++ b/features/src/cuda/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "CUDA Toolkit",
   "id": "cuda",
-  "version": "23.8.0",
+  "version": "23.8.1",
   "description": "A feature to install the NVIDIA CUDA Toolkit",
   "options": {
     "version": {

--- a/features/src/gcc/common/install.sh
+++ b/features/src/gcc/common/install.sh
@@ -26,11 +26,6 @@ export BASH_ENV=/etc/bash.bash_env;
 EOF
 )";
 
-# Ensure that login shells get the correct path if the user updated the PATH using ENV.
-rm -f /etc/profile.d/00-restore-env.sh
-echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
-chmod +x /etc/profile.d/00-restore-env.sh
-
 if ! grep -qE '^BASH_ENV=/etc/bash.bash_env$' /etc/environment; then
     echo "BASH_ENV=/etc/bash.bash_env" >> /etc/environment;
 fi

--- a/features/src/gcc/devcontainer-feature.json
+++ b/features/src/gcc/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "GCC",
   "id": "gcc",
-  "version": "23.8.1",
+  "version": "23.8.2",
   "description": "A feature to install gcc",
   "options": {
     "version": {

--- a/features/src/gitlab-cli/common/install.sh
+++ b/features/src/gitlab-cli/common/install.sh
@@ -26,11 +26,6 @@ export BASH_ENV=/etc/bash.bash_env;
 EOF
 )";
 
-# Ensure that login shells get the correct path if the user updated the PATH using ENV.
-rm -f /etc/profile.d/00-restore-env.sh
-echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
-chmod +x /etc/profile.d/00-restore-env.sh
-
 if ! grep -qE '^BASH_ENV=/etc/bash.bash_env$' /etc/environment; then
     echo "BASH_ENV=/etc/bash.bash_env" >> /etc/environment;
 fi

--- a/features/src/gitlab-cli/devcontainer-feature.json
+++ b/features/src/gitlab-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "gitlab-cli",
-  "version": "23.8.0",
+  "version": "23.8.1",
   "name": "GitLab CLI",
   "documentationURL": "https://github.com/rapidsai/devcontainers/features/tree/main/src/gitlab-cli",
   "description": "Installs the GitLab CLI. Auto-detects latest version and installs needed dependencies.",

--- a/features/src/llvm/common/install.sh
+++ b/features/src/llvm/common/install.sh
@@ -26,11 +26,6 @@ export BASH_ENV=/etc/bash.bash_env;
 EOF
 )";
 
-# Ensure that login shells get the correct path if the user updated the PATH using ENV.
-rm -f /etc/profile.d/00-restore-env.sh
-echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
-chmod +x /etc/profile.d/00-restore-env.sh
-
 if ! grep -qE '^BASH_ENV=/etc/bash.bash_env$' /etc/environment; then
     echo "BASH_ENV=/etc/bash.bash_env" >> /etc/environment;
 fi

--- a/features/src/llvm/devcontainer-feature.json
+++ b/features/src/llvm/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "LLVM compilers and tools",
   "id": "llvm",
-  "version": "23.8.0",
+  "version": "23.8.1",
   "description": "A feature to install LLVM compilers and tools",
   "options": {
     "version": {

--- a/features/src/mambaforge/.bashrc
+++ b/features/src/mambaforge/.bashrc
@@ -2,7 +2,7 @@ export MAMBA_NO_BANNER="${MAMBA_NO_BANNER:-1}";
 
 for default_conda_env_name in ${DEFAULT_CONDA_ENV:-} ${CONDA_DEFAULT_ENV:-} base; do
     if [ -z "${default_conda_env_name:-}" ]; then continue; fi
-    if echo "${CONDA_PROMPT_MODIFIER:-}" | grep -qF "($default_conda_env_name)"; then
+    if grep -qF "(${default_conda_env_name})" <<< "${CONDA_PROMPT_MODIFIER:-}"; then
         break;
     fi
     conda activate "$default_conda_env_name" 2>/dev/null && break || continue;

--- a/features/src/mambaforge/common/install.sh
+++ b/features/src/mambaforge/common/install.sh
@@ -26,11 +26,6 @@ export BASH_ENV=/etc/bash.bash_env;
 EOF
 )";
 
-# Ensure that login shells get the correct path if the user updated the PATH using ENV.
-rm -f /etc/profile.d/00-restore-env.sh
-echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
-chmod +x /etc/profile.d/00-restore-env.sh
-
 if ! grep -qE '^BASH_ENV=/etc/bash.bash_env$' /etc/environment; then
     echo "BASH_ENV=/etc/bash.bash_env" >> /etc/environment;
 fi

--- a/features/src/mambaforge/devcontainer-feature.json
+++ b/features/src/mambaforge/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Mambaforge",
   "id": "mambaforge",
-  "version": "23.8.3",
+  "version": "23.8.4",
   "description": "A feature to install mambaforge",
   "options": {
     "version": {

--- a/features/src/ninja/common/install.sh
+++ b/features/src/ninja/common/install.sh
@@ -26,11 +26,6 @@ export BASH_ENV=/etc/bash.bash_env;
 EOF
 )";
 
-# Ensure that login shells get the correct path if the user updated the PATH using ENV.
-rm -f /etc/profile.d/00-restore-env.sh
-echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
-chmod +x /etc/profile.d/00-restore-env.sh
-
 if ! grep -qE '^BASH_ENV=/etc/bash.bash_env$' /etc/environment; then
     echo "BASH_ENV=/etc/bash.bash_env" >> /etc/environment;
 fi

--- a/features/src/ninja/devcontainer-feature.json
+++ b/features/src/ninja/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Ninja build",
   "id": "ninja",
-  "version": "23.8.0",
+  "version": "23.8.1",
   "description": "A feature to install ninja-build",
   "options": {
     "version": {

--- a/features/src/nvhpc/common/install.sh
+++ b/features/src/nvhpc/common/install.sh
@@ -26,11 +26,6 @@ export BASH_ENV=/etc/bash.bash_env;
 EOF
 )";
 
-# Ensure that login shells get the correct path if the user updated the PATH using ENV.
-rm -f /etc/profile.d/00-restore-env.sh
-echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
-chmod +x /etc/profile.d/00-restore-env.sh
-
 if ! grep -qE '^BASH_ENV=/etc/bash.bash_env$' /etc/environment; then
     echo "BASH_ENV=/etc/bash.bash_env" >> /etc/environment;
 fi

--- a/features/src/nvhpc/devcontainer-feature.json
+++ b/features/src/nvhpc/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVHPC SDK",
   "id": "nvhpc",
-  "version": "23.8.0",
+  "version": "23.8.1",
   "description": "A feature to install the NVHPC SDK",
   "options": {
     "version": {

--- a/features/src/oneapi/common/install.sh
+++ b/features/src/oneapi/common/install.sh
@@ -26,11 +26,6 @@ export BASH_ENV=/etc/bash.bash_env;
 EOF
 )";
 
-# Ensure that login shells get the correct path if the user updated the PATH using ENV.
-rm -f /etc/profile.d/00-restore-env.sh
-echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
-chmod +x /etc/profile.d/00-restore-env.sh
-
 if ! grep -qE '^BASH_ENV=/etc/bash.bash_env$' /etc/environment; then
     echo "BASH_ENV=/etc/bash.bash_env" >> /etc/environment;
 fi

--- a/features/src/oneapi/devcontainer-feature.json
+++ b/features/src/oneapi/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Intel oneapi toolchain",
   "id": "oneapi",
-  "version": "23.8.0",
+  "version": "23.8.1",
   "description": "A feature to install the Intel oneapi toolchain",
   "options": {
     "version": {

--- a/features/src/python-lit/common/install.sh
+++ b/features/src/python-lit/common/install.sh
@@ -26,11 +26,6 @@ export BASH_ENV=/etc/bash.bash_env;
 EOF
 )";
 
-# Ensure that login shells get the correct path if the user updated the PATH using ENV.
-rm -f /etc/profile.d/00-restore-env.sh
-echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
-chmod +x /etc/profile.d/00-restore-env.sh
-
 if ! grep -qE '^BASH_ENV=/etc/bash.bash_env$' /etc/environment; then
     echo "BASH_ENV=/etc/bash.bash_env" >> /etc/environment;
 fi

--- a/features/src/python-lit/devcontainer-feature.json
+++ b/features/src/python-lit/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "python-lit testing framework",
   "id": "python-lit",
-  "version": "23.8.0",
+  "version": "23.8.1",
   "description": "A feature to install python-lit",
   "options": {
     "version": {

--- a/features/src/rapids-build-utils/common/install.sh
+++ b/features/src/rapids-build-utils/common/install.sh
@@ -26,11 +26,6 @@ export BASH_ENV=/etc/bash.bash_env;
 EOF
 )";
 
-# Ensure that login shells get the correct path if the user updated the PATH using ENV.
-rm -f /etc/profile.d/00-restore-env.sh
-echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
-chmod +x /etc/profile.d/00-restore-env.sh
-
 if ! grep -qE '^BASH_ENV=/etc/bash.bash_env$' /etc/environment; then
     echo "BASH_ENV=/etc/bash.bash_env" >> /etc/environment;
 fi

--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "23.8.2",
+  "version": "23.8.3",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rust/common/install.sh
+++ b/features/src/rust/common/install.sh
@@ -26,11 +26,6 @@ export BASH_ENV=/etc/bash.bash_env;
 EOF
 )";
 
-# Ensure that login shells get the correct path if the user updated the PATH using ENV.
-rm -f /etc/profile.d/00-restore-env.sh
-echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
-chmod +x /etc/profile.d/00-restore-env.sh
-
 if ! grep -qE '^BASH_ENV=/etc/bash.bash_env$' /etc/environment; then
     echo "BASH_ENV=/etc/bash.bash_env" >> /etc/environment;
 fi

--- a/features/src/rust/devcontainer-feature.json
+++ b/features/src/rust/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "rust",
-  "version": "23.8.0",
+  "version": "23.8.1",
   "name": "Rust",
   "documentationURL": "https://github.com/rapidsai/devcontainers/features/tree/main/src/rust",
   "description": "Installs Rust, common Rust utilities, and their required dependencies",

--- a/features/src/sccache/common/install.sh
+++ b/features/src/sccache/common/install.sh
@@ -26,11 +26,6 @@ export BASH_ENV=/etc/bash.bash_env;
 EOF
 )";
 
-# Ensure that login shells get the correct path if the user updated the PATH using ENV.
-rm -f /etc/profile.d/00-restore-env.sh
-echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
-chmod +x /etc/profile.d/00-restore-env.sh
-
 if ! grep -qE '^BASH_ENV=/etc/bash.bash_env$' /etc/environment; then
     echo "BASH_ENV=/etc/bash.bash_env" >> /etc/environment;
 fi

--- a/features/src/sccache/devcontainer-feature.json
+++ b/features/src/sccache/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "sccache",
   "id": "sccache",
-  "version": "23.8.0",
+  "version": "23.8.1",
   "description": "A feature to install sccache",
   "options": {
     "version": {

--- a/features/src/utils/common/install.sh
+++ b/features/src/utils/common/install.sh
@@ -26,11 +26,6 @@ export BASH_ENV=/etc/bash.bash_env;
 EOF
 )";
 
-# Ensure that login shells get the correct path if the user updated the PATH using ENV.
-rm -f /etc/profile.d/00-restore-env.sh
-echo "export PATH=${PATH//$(sh -lc 'echo $PATH')/\$PATH}" > /etc/profile.d/00-restore-env.sh
-chmod +x /etc/profile.d/00-restore-env.sh
-
 if ! grep -qE '^BASH_ENV=/etc/bash.bash_env$' /etc/environment; then
     echo "BASH_ENV=/etc/bash.bash_env" >> /etc/environment;
 fi

--- a/features/src/utils/devcontainer-feature.json
+++ b/features/src/utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "devcontainer-utils",
   "id": "utils",
-  "version": "23.8.4",
+  "version": "23.8.5",
   "description": "A feature to install RAPIDS devcontainer utility scripts",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/utils/install.sh
+++ b/features/src/utils/install.sh
@@ -101,7 +101,7 @@ for dir in $(for_each_user_bashrc 'echo "$(dirname "$(realpath -m "$0")")"'); do
     # Create ~/.cache, i.e. $XDG_CONFIG_HOME
     mkdir -p -m 0755 "${dir}"/.config/{clangd,pip};
     # Create ~/.local/state, i.e. $XDG_STATE_HOME
-    mkdir -p -m 0755 "${dir}"/.local/{bin,state};
+    mkdir -p -m 0755 "${dir}"/.local/state;
     # Create or update ~/.ssh/known_hosts
     mkdir -p -m 0700 "${dir}"/.ssh;
     touch "${dir}"/.ssh/known_hosts;
@@ -111,14 +111,26 @@ ${known_hosts}
 ____EOF
 done
 
+rm -rf /root/.cache;
+rm -rf /root/.local/{bin,state};
+rm -rf /root/.config/{clangd,pip};
+
 # Find the non-root user
 find_non_root_user;
+
+USERHOME="$(bash -c "echo ~${USERNAME}")";
+
 # Add user to the crontab group
-usermod -aG crontab ${USERNAME};
+usermod -aG crontab "${USERNAME}";
+
 # Allow user to edit the crontab
-echo ${USERNAME} >> /etc/cron.allow;
+echo "${USERNAME}" >> /etc/cron.allow;
+
+# Create ~/.cache, i.e. $XDG_CONFIG_HOME
+mkdir -p -m 0755 "${USERHOME}"/.local/bin;
+
 # Ensure the user owns their homedir
-chown -R ${USERNAME}:${USERNAME} "$(bash -c "echo ~${USERNAME}")";
+chown -R "${USERNAME}:${USERNAME}" "${USERHOME}";
 
 # Generate bash completions
 if dpkg -s bash-completion >/dev/null 2>&1; then


### PR DESCRIPTION
Now that all envvars are populated via `/etc/profile.d` scripts, this is causing build paths to leak into the container at run time.