### PR TITLE
add clone-all script + fix `gh repo list` saml issue

### DIFF
--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/generate-scripts.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/generate-scripts.sh
@@ -243,12 +243,14 @@ generate_scripts() {
 
     unset cpp_name_to_path;
 
-    # Generate a script to clone all repos
-    (
-        NAMES="${repo_name_all[@]}"       \
-        SCRIPT="clone"                    \
-        generate_all_script               ;
-    ) || true;
+    for script in "clone" "configure" "build"; do
+        # Generate a script to run a script for all repos
+        (
+            NAMES="${repo_name_all[@]}"       \
+            SCRIPT="${script}"                \
+            generate_all_script               ;
+        ) || true;
+    done;
 }
 
 if test -n "${rapids_build_utils_debug:-}"; then

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/generate-scripts.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/generate-scripts.sh
@@ -243,7 +243,7 @@ generate_scripts() {
 
     unset cpp_name_to_path;
 
-    for script in "clone" "configure" "build"; do
+    for script in "clone" "clean" "configure" "build"; do
         # Generate a script to run a script for all repos
         (
             NAMES="${repo_name_all[@]}"       \

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.tmpl.sh
@@ -1,8 +1,8 @@
-clone_all() {
+${SCRIPT}_all() {
     set -euo pipefail;
 
     for name in $NAMES; do
-        clone-$name
+        $SCRIPT-$name
     done;
 }
 
@@ -10,4 +10,4 @@ if [[ -n "$devcontainer_utils_debug" ]]; then
     PS4="+ ${BASH_SOURCE[0]}:\${LINENO} "; set -x;
 fi
 
-clone_all "$@";
+${SCRIPT}_all "$@";

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.tmpl.sh
@@ -1,0 +1,13 @@
+clone_all() {
+    set -euo pipefail;
+
+    for name in $NAMES; do
+        clone-$name
+    done;
+}
+
+if [[ -n "$devcontainer_utils_debug" ]]; then
+    PS4="+ ${BASH_SOURCE[0]}:\${LINENO} "; set -x;
+fi
+
+clone_all "$@";

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.tmpl.sh
@@ -2,7 +2,7 @@ ${SCRIPT}_all() {
     set -euo pipefail;
 
     for name in $NAMES; do
-        $SCRIPT-$name
+        $SCRIPT-$name "$@"
     done;
 }
 

--- a/features/src/utils/devcontainer-feature.json
+++ b/features/src/utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "devcontainer-utils",
   "id": "utils",
-  "version": "23.10.4",
+  "version": "23.10.5",
   "description": "A feature to install RAPIDS devcontainer utility scripts",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/utils/opt/devcontainer/bin/github/repo/clone.sh
+++ b/features/src/utils/opt/devcontainer/bin/github/repo/clone.sh
@@ -50,7 +50,7 @@ ________EOF
                 fi
             done
         fi
-        echo "${nameWithOwner:-}";
+        echo -n "${nameWithOwner:-}";
     fi
 }
 

--- a/features/src/utils/opt/devcontainer/bin/github/repo/clone.sh
+++ b/features/src/utils/opt/devcontainer/bin/github/repo/clone.sh
@@ -32,8 +32,7 @@ get_user_fork_name() {
     if [ "${user}" = "${owner}" ]; then
         echo "${owner}/${name}";
     else
-        gh repo list "${user}" --fork --json nameWithOwner --json parent --jq "$(cat <<________EOF | tr -s '[:space:]'
-            .
+        local query="$(cat <<________EOF | tr -s '[:space:]'
             | map(select(
                 .parent.name == "${name}"
                 and
@@ -42,6 +41,16 @@ get_user_fork_name() {
             | map(.nameWithOwner)[]
 ________EOF
         )";
+        local nameWithOwner="$(gh repo list "${user}" --fork --json nameWithOwner --json parent --jq ". ${query}" 2>/dev/null || echo "")";
+        if test -z "${nameWithOwner}"; then
+            for repo in $(gh repo list "${user}" --fork --json name --jq 'map(.name)[]'); do
+                nameWithOwner="$(gh repo view "${repo}" --json nameWithOwner --json parent --jq "[.] ${query}" 2>/dev/null || echo "")";
+                if test -n "${nameWithOwner}"; then
+                    break;
+                fi
+            done
+        fi
+        echo "${nameWithOwner:-}";
     fi
 }
 


### PR DESCRIPTION
added a generator for `clone-all` script (and can be reused for other `-all` scripts).

`gh repo list` fix created by @trxcllnt but introduced here since it was relevant to the work.

depends on #118