### PR TITLE
add utility to automatically configure ssh deploy keys in CI

### DIFF
--- a/features/src/utils/devcontainer-feature.json
+++ b/features/src/utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "devcontainer-utils",
   "id": "utils",
-  "version": "23.10.8",
+  "version": "23.10.9",
   "description": "A feature to install RAPIDS devcontainer utility scripts",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/utils/install.sh
+++ b/features/src/utils/install.sh
@@ -7,7 +7,17 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
 # install global/common scripts
 . ./common/install.sh;
 
-check_packages jq cron curl sudo wget tzdata gettext-base bash-completion ca-certificates;
+check_packages      \
+    jq              \
+    cron            \
+    curl            \
+    sudo            \
+    wget            \
+    tzdata          \
+    gettext-base    \
+    openssh-client  \
+    bash-completion \
+    ca-certificates ;
 
 # Install yq if not installed
 if ! type yq >/dev/null 2>&1; then
@@ -51,6 +61,8 @@ install_utility devcontainer-utils-post-attach-command-entrypoint post-attach-co
 install_utility devcontainer-utils-python-repl-startup python-repl-startup.py;
 install_utility devcontainer-utils-init-git git/init.sh;
 install_utility devcontainer-utils-clone-git-repo git/repo/clone.sh;
+
+install_utility devcontainer-utils-init-ssh-deploy-keys ssh/init-deploy-keys.sh;
 
 install_utility devcontainer-utils-init-github-cli   github/cli/init.sh;
 install_utility devcontainer-utils-clone-github-repo github/repo/clone.sh;

--- a/features/src/utils/opt/devcontainer/bin/ssh/init-deploy-keys.sh
+++ b/features/src/utils/opt/devcontainer/bin/ssh/init-deploy-keys.sh
@@ -1,0 +1,52 @@
+#! /usr/bin/env bash
+
+init_ssh_deploy_keys() {
+
+    set -euo pipefail;
+
+    local re="(ssh:\/\/|https:\/\/)?(git@)?(.*\.com)[:\/](.*)";
+    local line;
+
+    ssh-add -L | while read -r line; do
+        local key="$(cut -d' ' -f2 <<< "${line}")";
+        local url="$(cut -d' ' -f3 <<< "${line}")";
+        local sha="$(md5sum --tag <<< "${key}" | cut -d' ' -f4)";
+
+        if [[ ${url} =~ ${re} ]]; then
+
+            local host="${BASH_REMATCH[3]}";
+            local repo="${BASH_REMATCH[4]//.git/}";
+            local file="$HOME/.ssh/key-${sha}.pub";
+
+            if ! test -f "${file}"; then
+                cat <<________________EOF | tee -a "${file}" >/dev/null
+${line}
+________________EOF
+            fi
+
+            cat <<____________EOF | tee -a ~/.gitconfig >/dev/null
+[url "git@key-${sha}.${host}:${repo}"]
+  insteadOf = https://${host}/${repo}
+  insteadOf = git@${host}:${repo}
+  insteadOf = ssh://git@${host}/${repo}
+____________EOF
+
+            cat <<____________EOF | tee -a ~/.ssh/config >/dev/null
+Host key-${sha}.${host}
+    HostName ${host}
+    IdentityFile ${file}
+    IdentitiesOnly yes
+____________EOF
+
+        fi
+    done
+
+    chmod 0700 ~/.ssh;
+    chmod 0600 ~/.ssh/*;
+}
+
+if test -n "${devcontainer_utils_debug:-}"; then
+    PS4="+ ${BASH_SOURCE[0]}:\${LINENO} "; set -x;
+fi
+
+init_ssh_deploy_keys "$@";

--- a/features/test/utils/test.sh
+++ b/features/test/utils/test.sh
@@ -16,6 +16,40 @@ source dev-container-features-test-lib
 # The 'check' command comes from the dev-container-features-test-lib.
 check "post-attach-command.sh exists" stat /opt/devcontainer/bin/post-attach-command.sh
 
+eval "$(ssh-agent -s)";
+
+# Generate and add all sorts of keys/urls to the SSH agent
+for type in dsa rsa ecdsa ed25519; do
+    ssh-keygen -q -N "" -t "${type}" -f ~/.ssh/id_${type}_1 -C "git@github.com:rapidsai/devcontainers.git";
+    ssh-keygen -q -N "" -t "${type}" -f ~/.ssh/id_${type}_2 -C "https://github.com/rapidsai/devcontainers";
+    ssh-keygen -q -N "" -t "${type}" -f ~/.ssh/id_${type}_3 -C "https://github.com/rapidsai/devcontainers.git";
+    ssh-keygen -q -N "" -t "${type}" -f ~/.ssh/id_${type}_4 -C "ssh://git@github.com:rapidsai/devcontainers.git";
+    ssh-add -q ~/.ssh/id_${type}_1 ~/.ssh/id_${type}_2 ~/.ssh/id_${type}_3 ~/.ssh/id_${type}_4;
+done
+
+devcontainer-utils-init-ssh-deploy-keys;
+
+re="(ssh:\/\/|https:\/\/)?(git@)?(.*\.com)[:\/](.*)";
+
+# Verify the `devcontainer-utils-init-ssh-deploy-keys` script configured Git and SSH correctly
+for type in dsa rsa ecdsa ed25519; do
+    for i in 1 2 3 4; do
+        key="$(cut -d' ' -f2 < ~/.ssh/id_${type}_${i}.pub)";
+        url="$(cut -d' ' -f3 < ~/.ssh/id_${type}_${i}.pub)";
+        sha="$(md5sum --tag <<< "${key}" | cut -d' ' -f4)";
+        if [[ ${url} =~ ${re} ]]; then
+            host="${BASH_REMATCH[3]}";
+            repo="${BASH_REMATCH[4]//.git/}";
+            file="$HOME/.ssh/key-${sha}.pub";
+            check "id_${type}_${i}: public key exists" test -f "${file}";
+            check "id_${type}_${i}: ssh config has entry" grep -qE "^Host key-${sha}.${host}$" ~/.ssh/config;
+            check "id_${type}_${i}: gitconfig has entry" grep -qE "^\[url \"git@key\-${sha}.${host}:${repo}\"\]$" ~/.gitconfig;
+        else
+            check "${url} does not match regex" false;
+        fi
+    done
+done
+
 # Report result
 # If any of the checks above exited with a non-zero exit code, the test will fail.
 reportResults


### PR DESCRIPTION
Porting [this logic](https://github.com/rapidsai/shared-action-workflows/blob/b8b02fc70a2addcb40b330e60506c0d3c85be893/.github/workflows/build-in-devcontainer.yaml#L93-L144) to a devcontainer utility script because it's a common thing to need in CI.