### PR TITLE
Update install-cmake.ps1

### DIFF
--- a/windows/image/installers/install-cmake.ps1
+++ b/windows/image/installers/install-cmake.ps1
@@ -1,5 +1,5 @@
 # Fetch CMake
-Invoke-WebRequest -Uri "https://github.com/Kitware/CMake/releases/download/v3.26.3/cmake-3.26.3-windows-x86_64.msi" -OutFile "C:\cmake_installer.msi" -UseBasicParsing
+Invoke-WebRequest -Uri "https://github.com/Kitware/CMake/releases/download/v3.27.6/cmake-3.27.6-windows-x86_64.msi" -OutFile "C:\cmake_installer.msi" -UseBasicParsing
 Start-Process -NoNewWindow -Wait -FilePath msiexec -ArgumentList "/i C:\cmake_installer.msi ADD_CMAKE_TO_PATH=All /qn"
 Remove-Item "C:\cmake_installer.msi"
 


### PR DESCRIPTION
Due to a cmake bug we need at least cmake 3.27.5 to use RDC on windows. So just install the latest releast, which is 3.27.6