### PR TITLE
Only remove newly installed llvm packages and not always everything

### DIFF
--- a/features/src/llvm/install.sh
+++ b/features/src/llvm/install.sh
@@ -43,7 +43,9 @@ echo "Installing llvm-${LLVM_VERSION} compilers and tools";
 # Remove existing, install, and set default clang/llvm alternatives
 for x in clang clangd clang++ clang-format clang-tidy lldb llvm-config llvm-cov; do
     if type ${x}-${LLVM_VERSION} >/dev/null 2>&1; then
-        (update-alternatives --remove-all ${x} >/dev/null 2>&1 || true);
+        if ${x} != clang-format; then
+            (update-alternatives --remove-all ${x} >/dev/null 2>&1 || true);
+        fi
         (update-alternatives --install /usr/bin/${x} ${x} $(which ${x}-${LLVM_VERSION}) 30);
         (update-alternatives --set ${x} $(which ${x}-${LLVM_VERSION}));
     fi

--- a/matrix.yml
+++ b/matrix.yml
@@ -53,38 +53,38 @@ include:
 
 - os: "ubuntu:18.04"
   images:
-  - {features: [*gcc_6, {<<: *cuda_prev_min, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *gcc_env}
-  - {features: [*gcc_7, {<<: *cuda_prev_min, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *gcc_env}
-  - {features: [*gcc_8, {<<: *cuda_prev_min, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *gcc_env}
-  - {features: [*gcc_9, {<<: *cuda_prev_min, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *gcc_env}
-  - {features: [*llvm_9, {<<: *cuda_prev_min, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *llvm_env}
-  - {features: [*oneapi_2022, {<<: *cuda_prev_min, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *onapi_env}
+  - {features: [*gcc_6, {<<: *cuda_prev_min, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *gcc_env}
+  - {features: [*gcc_7, {<<: *cuda_prev_min, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *gcc_env}
+  - {features: [*gcc_8, {<<: *cuda_prev_min, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *gcc_env}
+  - {features: [*gcc_9, {<<: *cuda_prev_min, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *gcc_env}
+  - {features: [*llvm_9, {<<: *cuda_prev_min, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *llvm_env}
+  - {features: [*oneapi_2022, {<<: *cuda_prev_min, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *onapi_env}
 
 - os: "ubuntu:20.04"
   images:
-  - {features: [*gcc_7, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *gcc_env}
-  - {features: [*gcc_8, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *gcc_env}
-  - {features: [*gcc_9, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *gcc_env}
-  - {features: [*gcc_10, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *gcc_env}
-  - {features: [*llvm_9, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *llvm_env}
-  - {features: [*llvm_10, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *llvm_env}
-  - {features: [*llvm_11, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *llvm_env}
-  - {features: [*llvm_12, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *llvm_env}
-  - {features: [*llvm_13, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *llvm_env}
-  - {features: [*llvm_14, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *llvm_env}
-  - {features: [*oneapi_2022, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *onapi_env}
+  - {features: [*gcc_7, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *gcc_env}
+  - {features: [*gcc_8, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *gcc_env}
+  - {features: [*gcc_9, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *gcc_env}
+  - {features: [*gcc_10, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *gcc_env}
+  - {features: [*llvm_9, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *llvm_env}
+  - {features: [*llvm_10, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *llvm_env}
+  - {features: [*llvm_11, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *llvm_env}
+  - {features: [*llvm_12, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *llvm_env}
+  - {features: [*llvm_13, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *llvm_env}
+  - {features: [*llvm_14, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *llvm_env}
+  - {features: [*oneapi_2022, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *onapi_env}
 
 - os: "ubuntu:22.04"
   images:
-  - {features: [*nvhpc_prev, *python, *cccl_dev, *cccl_clang_format], env: *nvhpc_env}
-  - {features: [*nvhpc_curr, *python, *cccl_dev, *cccl_clang_format], env: *nvhpc_env}
-  - {features: [*gcc_11, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *gcc_env}
-  - {features: [*gcc_12, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *gcc_env}
-  - {features: [*gcc_13, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *gcc_env}
-  - {features: [*llvm_15, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *llvm_env}
-  - {features: [*llvm_prev, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *llvm_env}
-  - {features: [*llvm_curr, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *llvm_env}
-  - {features: [*oneapi_2022, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_dev, *cccl_clang_format], env: *onapi_env}
+  - {features: [*nvhpc_prev, *python, *cccl_clang_format, *cccl_dev], env: *nvhpc_env}
+  - {features: [*nvhpc_curr, *python, *cccl_clang_format, *cccl_dev], env: *nvhpc_env}
+  - {features: [*gcc_11, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *gcc_env}
+  - {features: [*gcc_12, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *gcc_env}
+  - {features: [*gcc_13, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *gcc_env}
+  - {features: [*llvm_15, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *llvm_env}
+  - {features: [*llvm_prev, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *llvm_env}
+  - {features: [*llvm_curr, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *llvm_env}
+  - {features: [*oneapi_2022, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_clang_format, *cccl_dev], env: *onapi_env}
   # llvm-cuda-nvhpc (needed by stdexec devcontainers)
   - {features: [*llvm_curr, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *nvhpc_curr, *python]}
 


### PR DESCRIPTION
We want to install a unique version of clang-format for our devcontainer

However, the current install script will remove all prior installs of llvm tools of a different version.

Rather than nuking everything we only replace the package we installed