### PR TITLE
Intels pub key for the oneAPI repo expired.

### DIFF
--- a/features/src/oneapi/install.sh
+++ b/features/src/oneapi/install.sh
@@ -30,7 +30,7 @@ if [ -f /etc/profile.d/lmod.sh ]; then
 fi
 
 # Add Intel repo signing key
-wget --no-hsts -q -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS.PUB \
+wget --no-hsts -q -O- https://apt.repos.intel.com/intel-gpg-keys/GPG-PUB-KEY-INTEL-SW-PRODUCTS-2023.PUB \
    | gpg --dearmor -o /etc/apt/trusted.gpg.d/oneapi-archive-keyring.gpg;
 
 chmod 0644 /etc/apt/trusted.gpg.d/*.gpg || true;


### PR DESCRIPTION
It seems they forgot to renew it for ubuntu 18.04 so our CI is broken. Just try to fetch the 2023 key and hope for the best