### PR TITLE
Windows: Add nvrtc*_dev* components to the windows images.

### DIFF
--- a/windows/image/installers/install-cuda.ps1
+++ b/windows/image/installers/install-cuda.ps1
@@ -39,7 +39,7 @@ $componentTag = @{
 $cudaVersionUrl = "https://developer.download.nvidia.com/compute/cuda/$cudaUri"
 
 Invoke-WebRequest -Uri "$cudaVersionUrl" -OutFile "./cuda_network.exe" -UseBasicParsing
-Start-Process -Wait -PassThru -FilePath .\cuda_network.exe -ArgumentList "-s nvcc_$componentTag curand_$componentTag curand_dev_$componentTag cudart_$componentTag nvrtc_$componentTag"
+Start-Process -Wait -PassThru -FilePath .\cuda_network.exe -ArgumentList "-s nvcc_$componentTag curand_$componentTag curand_dev_$componentTag cudart_$componentTag nvrtc_$componentTag nvrtc_dev_$componentTag"
 
 $ENV:PATH="$ENV:PATH;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$componentTag\bin"
 $ENV:CUDA_PATH="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$componentTag"


### PR DESCRIPTION
Apparently dev components are separate. Effectively there are no NVRTC build components available yet on Windows and instead only runtime. 