### PR TITLE
Use env.RUNNER_ENVIRONMENT to check runner type

### DIFF
--- a/.github/actions/devcontainer-json/action.yml
+++ b/.github/actions/devcontainer-json/action.yml
@@ -21,8 +21,8 @@ runs:
   using: composite
   steps:
 
-    - name: Setup Node.js
-      if: contains(runner.name, 'linux-') == true
+    - if: env.RUNNER_ENVIRONMENT != 'github-hosted'
+      name: Setup Node.js
       uses: actions/setup-node@v3
       with:
         node-version: '16'

--- a/.github/actions/setup-runner-env/action.yml
+++ b/.github/actions/setup-runner-env/action.yml
@@ -6,26 +6,26 @@ runs:
   using: composite
   steps:
 
-    - if: contains(runner.name, 'linux-') != true
+    - if: env.RUNNER_ENVIRONMENT == 'github-hosted'
       name: Free up disk space
       uses: ./.github/actions/free-disk-space
       with:
         tool_cache: "${{ runner.tool_cache }}"
 
-    - if: contains(runner.name, 'linux-') == true
+    - if: env.RUNNER_ENVIRONMENT != 'github-hosted'
       name: Setup self-hosted runner environment
       shell: bash -eo pipefail {0}
       run: |
         echo "HOME=${{ runner.workspace }}" >> $GITHUB_ENV;
         echo "TMPDIR=${{ runner.temp }}" >> $GITHUB_ENV;
 
-    - if: contains(runner.name, 'linux-') == true
+    - if: env.RUNNER_ENVIRONMENT != 'github-hosted'
       name: Setup Node.js
       uses: actions/setup-node@v3
       with:
         node-version: '16'
 
-    - if: contains(runner.name, 'linux-') != true
+    - if: env.RUNNER_ENVIRONMENT == 'github-hosted'
       name: Set up QEMU
       uses: docker/setup-qemu-action@v2
 


### PR DESCRIPTION
Instead of checking if the runner name contains `linux-`, we now check the value of `env.RUNNER_ENVIRONMENT`. This value should be `github-hosted` for GitHub runners and `self-hosted` for RAPIDS runners.

Test pipeline: https://github.com/rapidsai/devcontainers/actions/runs/6639045230?pr=166