### PR TITLE
Update newest CUDA to 12.3

### DIFF
--- a/matrix.yml
+++ b/matrix.yml
@@ -1,7 +1,7 @@
 x-cuda-prev-min: &cuda_prev_min { name: "cuda", version: "11.1" }
 x-cuda-prev-max: &cuda_prev_max { name: "cuda", version: "11.8" }
 x-cuda-curr-min: &cuda_curr_min { name: "cuda", version: "12.0" }
-x-cuda-curr-max: &cuda_curr_max { name: "cuda", version: "12.2" }
+x-cuda-curr-max: &cuda_curr_max { name: "cuda", version: "12.3" }
 
 x-gcc-6: &gcc_6 { name: "gcc", version: "6" }
 x-gcc-7: &gcc_7 { name: "gcc", version: "7" }

--- a/windows/image/installers/install-cuda.ps1
+++ b/windows/image/installers/install-cuda.ps1
@@ -17,7 +17,7 @@ $cudaUri = @{
     "12.1"   = "12.1.1/network_installers/cuda_12.1.1_windows_network.exe"
     "12.2"   = "12.2.0/network_installers/cuda_12.2.0_windows_network.exe"
     "12.2.0" = "12.2.0/network_installers/cuda_12.2.0_windows_network.exe"
-    "12.3.0" = "12.3.0/network_installers/cuda_12.2.0_windows_network.exe"
+    "12.3.0" = "12.3.0/network_installers/cuda_12.3.0_windows_network.exe"
     "latest" = "12.3.0/network_installers/cuda_12.2.0_windows_network.exe"
 }[$cudaVersion]
 

--- a/windows/image/installers/install-cuda.ps1
+++ b/windows/image/installers/install-cuda.ps1
@@ -17,7 +17,8 @@ $cudaUri = @{
     "12.1"   = "12.1.1/network_installers/cuda_12.1.1_windows_network.exe"
     "12.2"   = "12.2.0/network_installers/cuda_12.2.0_windows_network.exe"
     "12.2.0" = "12.2.0/network_installers/cuda_12.2.0_windows_network.exe"
-    "latest" = "12.2.0/network_installers/cuda_12.2.0_windows_network.exe"
+    "12.3.0" = "12.3.0/network_installers/cuda_12.2.0_windows_network.exe"
+    "latest" = "12.3.0/network_installers/cuda_12.2.0_windows_network.exe"
 }[$cudaVersion]
 
 # The component tags don't include patch, so we need to map input to major.minor
@@ -33,7 +34,9 @@ $componentTag = @{
     "12.1"   = "12.1"
     "12.2"   = "12.2"
     "12.2.0" = "12.2"
-    "latest" = "12.2"
+    "12.3"   = "12.3"
+    "12.3.0" = "12.3"
+    "latest" = "12.3"
 }[$cudaVersion]
 
 $cudaVersionUrl = "https://developer.download.nvidia.com/compute/cuda/$cudaUri"

--- a/windows/image/installers/install-cuda.ps1
+++ b/windows/image/installers/install-cuda.ps1
@@ -18,7 +18,7 @@ $cudaUri = @{
     "12.2"   = "12.2.0/network_installers/cuda_12.2.0_windows_network.exe"
     "12.2.0" = "12.2.0/network_installers/cuda_12.2.0_windows_network.exe"
     "12.3.0" = "12.3.0/network_installers/cuda_12.3.0_windows_network.exe"
-    "latest" = "12.3.0/network_installers/cuda_12.2.0_windows_network.exe"
+    "latest" = "12.3.0/network_installers/cuda_12.3.0_windows_network.exe"
 }[$cudaVersion]
 
 # The component tags don't include patch, so we need to map input to major.minor

--- a/windows/image/installers/install-cuda.ps1
+++ b/windows/image/installers/install-cuda.ps1
@@ -17,6 +17,7 @@ $cudaUri = @{
     "12.1"   = "12.1.1/network_installers/cuda_12.1.1_windows_network.exe"
     "12.2"   = "12.2.0/network_installers/cuda_12.2.0_windows_network.exe"
     "12.2.0" = "12.2.0/network_installers/cuda_12.2.0_windows_network.exe"
+    "12.3"   = "12.3.0/network_installers/cuda_12.3.0_windows_network.exe"
     "12.3.0" = "12.3.0/network_installers/cuda_12.3.0_windows_network.exe"
     "latest" = "12.3.0/network_installers/cuda_12.3.0_windows_network.exe"
 }[$cudaVersion]


### PR DESCRIPTION
Since 12.3 was recently released, updating the images to use 12.3 for `cuda_curr_max`. 