### PR TITLE
Add CUDA 11.8 devcontainer to CCCL matrix

### DIFF
--- a/matrix.yml
+++ b/matrix.yml
@@ -77,6 +77,7 @@ include:
   images:
   - {features: [*nvhpc_prev, *python, *cccl_dev], env: *nvhpc_env}
   - {features: [*nvhpc_curr, *python, *cccl_dev], env: *nvhpc_env}
+  - {features: [*gcc_11, {<<: *cuda_prev_max, <<: *cccl_cuda_opts}, *python, *cccl_dev], env: *gcc_env}
   - {features: [*gcc_11, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_dev], env: *gcc_env}
   - {features: [*gcc_12, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_dev], env: *gcc_env}
   - {features: [*gcc_13, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *python, *cccl_dev], env: *gcc_env}


### PR DESCRIPTION
This PR adds a single image to the CCCL devcontainer matrix which is needed to run cuCollections CI tests.


CC @jrhemstad @bdice 