### PR TITLE
Fix CUDA version detection mechanism

### DIFF
--- a/features/src/cuda/devcontainer-feature.json
+++ b/features/src/cuda/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "CUDA Toolkit",
   "id": "cuda",
-  "version": "24.2.0",
+  "version": "24.2.1",
   "description": "A feature to install the NVIDIA CUDA Toolkit",
   "options": {
     "version": {

--- a/features/src/cuda/install.sh
+++ b/features/src/cuda/install.sh
@@ -65,7 +65,7 @@ echo "Installing dev CUDA toolkit...";
 export CUDA_HOME="/usr/local/cuda";
 
 cuda_ver="${VERSION}";
-cuda_ver=$(cut -d'.' -f3 --complement <<< "${cuda_ver}");
+cuda_ver=$(grep -o '^[0-9]*.[0-9]' <<< "${cuda_ver}");
 
 cudapath="${CUDA_HOME}-${cuda_ver}";
 cuda_tag="cuda${cuda_ver}";

--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.2.1",
+  "version": "24.2.2",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-env.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-env.sh
@@ -14,7 +14,7 @@ make_conda_env() {
     fi
 
     local cuda_version="${CUDA_VERSION:-${CUDA_VERSION_MAJOR:-12}.${CUDA_VERSION_MINOR:-0}}";
-    cuda_version="$(cut -d'.' -f3 --complement <<< "${cuda_version}")";
+    cuda_version="$(grep -o '^[0-9]*.[0-9]' <<< "${cuda_version}")";
 
     local python_version="${PYTHON_VERSION:-$(python3 --version 2>&1 | cut -d' ' -f2)}";
     python_version="$(cut -d'.' -f3 --complement <<< "${python_version}")";

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-pip-env.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-pip-env.sh
@@ -14,7 +14,7 @@ make_pip_env() {
     fi
 
     local cuda_version="${CUDA_VERSION:-${CUDA_VERSION_MAJOR:-12}.${CUDA_VERSION_MINOR:-0}}";
-    cuda_version="$(cut -d'.' -f3 --complement <<< "${cuda_version}")";
+    cuda_version="$(grep -o '^[0-9]*.[0-9]' <<< "${cuda_version}")";
     local cuda_version_major="$(cut -d'.' -f1 <<< "${cuda_version}")";
 
     local python_version="${PYTHON_VERSION:-$(python3 --version 2>&1 | cut -d' ' -f2)}";


### PR DESCRIPTION
CUDA major/minor version detection only works when `CUDA_VERSION` is comprised of two-or-three version components (x.y or x.y.z, for instance), but fails with never versions which have 4 components (x.y.z.w). This PR fixes detection for the latter case.