### PR TITLE
Avoid mamba issues with updating envs with pip dependencies

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.2.2",
+  "version": "24.2.3",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-env.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-env.sh
@@ -88,12 +88,8 @@ make_conda_env() {
              && echo "";
 
             # Update the current conda env + prune libs that were removed
-            # conda fallback for https://github.com/mamba-org/mamba/issues/3059
-            if grep -q "pip:" ${new_env_path}; then
-                conda env update -n "${env_name}" -f "${new_env_path}" --prune --solver=libmamba
-            else
-                mamba env update -n "${env_name}" -f "${new_env_path}" --prune
-            fi
+            # Use conda instead of mamba due to https://github.com/mamba-org/mamba/issues/3059
+            conda env update -n "${env_name}" -f "${new_env_path}" --prune --solver=libmamba
         fi
 
         cp -a "${new_env_path}" "${old_env_path}";

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-env.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-env.sh
@@ -88,7 +88,11 @@ make_conda_env() {
              && echo "";
 
             # Update the current conda env + prune libs that were removed
-            mamba env update -n "${env_name}" -f "${new_env_path}" --prune;
+            if grep -q "pip:" ${new_env_path}; then
+                conda env update -n "${env_name}" -f "${new_env_path}" --prune --solver=libmamba
+            else
+                mamba env update -n "${env_name}" -f "${new_env_path}" --prune
+            fi
         fi
 
         cp -a "${new_env_path}" "${old_env_path}";

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-env.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-env.sh
@@ -88,6 +88,7 @@ make_conda_env() {
              && echo "";
 
             # Update the current conda env + prune libs that were removed
+            # conda fallback for https://github.com/mamba-org/mamba/issues/3059
             if grep -q "pip:" ${new_env_path}; then
                 conda env update -n "${env_name}" -f "${new_env_path}" --prune --solver=libmamba
             else


### PR DESCRIPTION
If pip dependencies are detected in the generated dependency file, this PR changes `rapids-make-conda-env` to use conda instead of mamba for the env update. This is necessary because of https://github.com/mamba-org/mamba/issues/3059.

I still use mamba when no pip dependencies are present because it is marginally faster at preprocessing metadata outside of the solve.