### PR TITLE
Update Python clean templates for scikit-build-core

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.2.2",
+  "version": "24.2.3",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python-clean.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python-clean.tmpl.sh
@@ -23,6 +23,12 @@ clean_${PY_LIB}_cpp() {
         fi
     done
 
+    if test -d ~/"${PY_SRC}"/build; then
+        for d in ~/"${PY_SRC}"/build/cp${python_version}-cp${python_version}*; do
+            rm -rf $d
+        done
+    fi
+
     if test -d ~/"${PY_SRC}/${PY_LIB}"/; then
         find ~/"${PY_SRC}/${PY_LIB}"/ -type f \
             -iname "*.cpython-*-$(uname -m)-$(uname -s)-*.so" \


### PR DESCRIPTION
With scikit-build-core all of our packages are configured to place the built wheels in a directory corresponding to the wheel tags. This change allows the clean scripts in devcontainers to properly clean those up.