### PR TITLE
Update `rapids-build-utils` version after #189

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.2.3",
+  "version": "24.2.4",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"


### PR DESCRIPTION
#189 updated the version to the version it already was in `branch-24.02`. This PR bumps to the next patch version so the changes in #189 are published.