### PR TITLE
Add wholegraph to `manifest.yaml`

### DIFF
--- a/.devcontainer/build-rapids.sh
+++ b/.devcontainer/build-rapids.sh
@@ -26,72 +26,71 @@ build_rapids() {
     (
         echo "building RMM";
         clean-rmm;
-        build-rmm -DBUILD_BENCHMARKS=ON;
+        build-rmm -DBUILD_BENCHMARKS=ON --verbose;
         sccache -s;
     ) 2>&1 | maybe_write_build_log rmm;
 
     (
         echo "building KvikIO";
         clean-kvikio;
-        build-kvikio-cpp;
-        build-kvikio-python;
+        build-kvikio --verbose;
         sccache -s;
     ) 2>&1 | maybe_write_build_log kvikio;
 
     (
         echo "building cuDF";
         clean-cudf;
-    CUDF_ROOT=~/cudf/cpp/build/latest \
-    CUDF_INCLUDE_DIR=~/cudf/cpp/include \
-    CUDF_KAFKA_ROOT=~/cudf/cpp/libcudf_kafka/build/latest \
-    CUDF_KAFKA_INCLUDE_DIR=~/cudf/cpp/libcudf_kafka/include \
-    CUDA_HOME="${CONDA_PREFIX:-${CUDA_HOME:-/usr/local/cuda}}" \
-    C_INCLUDE_PATH=${C_INCLUDE_PATH:-}:~/rmm/include:~/rmm/build/latest/include \
-    CPLUS_INCLUDE_PATH=${CPLUS_INCLUDE_PATH:-}:~/rmm/include:~/rmm/build/latest/include \
-        build-cudf -DBUILD_BENCHMARKS=ON;
+        build-cudf -DBUILD_BENCHMARKS=ON -DNVBench_ENABLE_CUPTI=OFF --verbose
         sccache -s;
     ) 2>&1 | maybe_write_build_log cudf;
 
     (
         echo "building RAFT";
         clean-raft;
-        build-raft -DBUILD_PRIMS_BENCH=ON -DBUILD_ANN_BENCH=ON;
+        build-raft -DBUILD_PRIMS_BENCH=ON -DBUILD_ANN_BENCH=ON --verbose;
         sccache -s;
     ) 2>&1 | maybe_write_build_log raft;
 
     (
         echo "building cuMLPrims";
         clean-cumlprims_mg;
-        build-cumlprims_mg;
+        build-cumlprims_mg --verbose;
         sccache -s;
     ) 2>&1 | maybe_write_build_log cumlprims_mg;
 
     (
         echo "building cuML";
         clean-cuml;
-        build-cuml;
+        build-cuml --verbose;
         sccache -s;
     ) 2>&1 | maybe_write_build_log cuml;
 
     (
         echo "building cuGraph OPS";
         clean-cugraph-ops;
-        build-cugraph-ops;
+        build-cugraph-ops --verbose;
         sccache -s;
     ) 2>&1 | maybe_write_build_log cugraph-ops;
+
+    (
+        echo "building wholegraph";
+        clean-wholegraph;
+        build-wholegraph --verbose;
+        sccache -s;
+    ) 2>&1 | maybe_write_build_log wholegraph;
 
     (
         echo "building cuGraph";
         clean-cugraph;
     CUDA_HOME="${CONDA_PREFIX:-${CUDA_HOME:-/usr/local/cuda}}" \
-        build-cugraph --max-device-obj-memory-usage 5;
+        build-cugraph --verbose --max-device-obj-memory-usage 5;
         sccache -s;
     ) 2>&1 | maybe_write_build_log cugraph;
 
     (
         echo "building cuSpatial";
         clean-cuspatial;
-        build-cuspatial -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON;
+        build-cuspatial -DBUILD_TESTS=ON -DBUILD_BENCHMARKS=ON --verbose;
         sccache -s;
     ) 2>&1 | maybe_write_build_log cuspatial;
 

--- a/.devcontainer/cuda11.8-conda/devcontainer.json
+++ b/.devcontainer/cuda11.8-conda/devcontainer.json
@@ -15,7 +15,7 @@
   "overrideFeatureInstallOrder": [
     "./features/rapids-build-utils"
   ],
-  "initializeCommand": ["/bin/bash", "-c", "mkdir -m 0755 -p ${localWorkspaceFolder}/../.{aws,cache,config,conda/pkgs,conda/${localWorkspaceFolderBasename}-cuda11.8-envs} ${localWorkspaceFolder}/../{rmm,kvikio,cudf,raft,cumlprims_mg,cuml,cugraph-ops,cugraph,cuspatial}"],
+  "initializeCommand": ["/bin/bash", "-c", "mkdir -m 0755 -p ${localWorkspaceFolder}/../.{aws,cache,config,conda/pkgs,conda/${localWorkspaceFolderBasename}-cuda11.8-envs} ${localWorkspaceFolder}/../{rmm,kvikio,cudf,raft,cumlprims_mg,cuml,cugraph-ops,wholegraph,cugraph,cuspatial}"],
   "postAttachCommand": ["/bin/bash", "-c", "if [ ${CODESPACES:-false} = 'true' ]; then . devcontainer-utils-post-attach-command; . rapids-post-attach-command; fi"],
   "workspaceFolder": "/home/coder",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/devcontainers,type=bind,consistency=consistent",
@@ -27,6 +27,7 @@
     "source=${localWorkspaceFolder}/../cumlprims_mg,target=/home/coder/cumlprims_mg,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../cuml,target=/home/coder/cuml,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../cugraph-ops,target=/home/coder/cugraph-ops,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../wholegraph,target=/home/coder/wholegraph,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../cugraph,target=/home/coder/cugraph,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../cuspatial,target=/home/coder/cuspatial,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../.aws,target=/home/coder/.aws,type=bind,consistency=consistent",

--- a/.devcontainer/cuda11.8-pip/devcontainer.json
+++ b/.devcontainer/cuda11.8-pip/devcontainer.json
@@ -17,7 +17,7 @@
     "./features/cuda",
     "./features/rapids-build-utils"
   ],
-  "initializeCommand": ["/bin/bash", "-c", "mkdir -m 0755 -p ${localWorkspaceFolder}/../.{aws,cache,config/pip,local/share/${localWorkspaceFolderBasename}-cuda11.8-venvs} ${localWorkspaceFolder}/../{rmm,kvikio,cudf,raft,cumlprims_mg,cuml,cugraph-ops,cugraph,cuspatial}"],
+  "initializeCommand": ["/bin/bash", "-c", "mkdir -m 0755 -p ${localWorkspaceFolder}/../.{aws,cache,config/pip,local/share/${localWorkspaceFolderBasename}-cuda11.8-venvs} ${localWorkspaceFolder}/../{rmm,kvikio,cudf,raft,cumlprims_mg,cuml,cugraph-ops,wholegraph,cugraph,cuspatial}"],
   "postAttachCommand": ["/bin/bash", "-c", "if [ ${CODESPACES:-false} = 'true' ]; then . devcontainer-utils-post-attach-command; . rapids-post-attach-command; fi"],
   "workspaceFolder": "/home/coder",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/devcontainers,type=bind,consistency=consistent",
@@ -29,6 +29,7 @@
     "source=${localWorkspaceFolder}/../cumlprims_mg,target=/home/coder/cumlprims_mg,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../cuml,target=/home/coder/cuml,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../cugraph-ops,target=/home/coder/cugraph-ops,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../wholegraph,target=/home/coder/wholegraph,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../cugraph,target=/home/coder/cugraph,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../cuspatial,target=/home/coder/cuspatial,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../.aws,target=/home/coder/.aws,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.0-conda/devcontainer.json
+++ b/.devcontainer/cuda12.0-conda/devcontainer.json
@@ -15,7 +15,7 @@
   "overrideFeatureInstallOrder": [
     "./features/rapids-build-utils"
   ],
-  "initializeCommand": ["/bin/bash", "-c", "mkdir -m 0755 -p ${localWorkspaceFolder}/../.{aws,cache,config,conda/pkgs,conda/${localWorkspaceFolderBasename}-cuda12.0-envs} ${localWorkspaceFolder}/../{rmm,kvikio,cudf,raft,cumlprims_mg,cuml,cugraph-ops,cugraph,cuspatial}"],
+  "initializeCommand": ["/bin/bash", "-c", "mkdir -m 0755 -p ${localWorkspaceFolder}/../.{aws,cache,config,conda/pkgs,conda/${localWorkspaceFolderBasename}-cuda12.0-envs} ${localWorkspaceFolder}/../{rmm,kvikio,cudf,raft,cumlprims_mg,cuml,cugraph-ops,wholegraph,cugraph,cuspatial}"],
   "postAttachCommand": ["/bin/bash", "-c", "if [ ${CODESPACES:-false} = 'true' ]; then . devcontainer-utils-post-attach-command; . rapids-post-attach-command; fi"],
   "workspaceFolder": "/home/coder",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/devcontainers,type=bind,consistency=consistent",
@@ -27,6 +27,7 @@
     "source=${localWorkspaceFolder}/../cumlprims_mg,target=/home/coder/cumlprims_mg,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../cuml,target=/home/coder/cuml,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../cugraph-ops,target=/home/coder/cugraph-ops,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../wholegraph,target=/home/coder/wholegraph,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../cugraph,target=/home/coder/cugraph,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../cuspatial,target=/home/coder/cuspatial,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../.aws,target=/home/coder/.aws,type=bind,consistency=consistent",

--- a/.devcontainer/cuda12.0-pip/devcontainer.json
+++ b/.devcontainer/cuda12.0-pip/devcontainer.json
@@ -17,7 +17,7 @@
     "./features/cuda",
     "./features/rapids-build-utils"
   ],
-  "initializeCommand": ["/bin/bash", "-c", "mkdir -m 0755 -p ${localWorkspaceFolder}/../.{aws,cache,config/pip,local/share/${localWorkspaceFolderBasename}-cuda12.0-venvs} ${localWorkspaceFolder}/../{rmm,kvikio,cudf,raft,cumlprims_mg,cuml,cugraph-ops,cugraph,cuspatial}"],
+  "initializeCommand": ["/bin/bash", "-c", "mkdir -m 0755 -p ${localWorkspaceFolder}/../.{aws,cache,config/pip,local/share/${localWorkspaceFolderBasename}-cuda12.0-venvs} ${localWorkspaceFolder}/../{rmm,kvikio,cudf,raft,cumlprims_mg,cuml,cugraph-ops,wholegraph,cugraph,cuspatial}"],
   "postAttachCommand": ["/bin/bash", "-c", "if [ ${CODESPACES:-false} = 'true' ]; then . devcontainer-utils-post-attach-command; . rapids-post-attach-command; fi"],
   "workspaceFolder": "/home/coder",
   "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/devcontainers,type=bind,consistency=consistent",
@@ -29,6 +29,7 @@
     "source=${localWorkspaceFolder}/../cumlprims_mg,target=/home/coder/cumlprims_mg,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../cuml,target=/home/coder/cuml,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../cugraph-ops,target=/home/coder/cugraph-ops,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../wholegraph,target=/home/coder/wholegraph,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../cugraph,target=/home/coder/cugraph,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../cuspatial,target=/home/coder/cuspatial,type=bind,consistency=consistent",
     "source=${localWorkspaceFolder}/../.aws,target=/home/coder/.aws,type=bind,consistency=consistent",

--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.2.4",
+  "version": "24.2.5",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -120,6 +120,20 @@ repos:
     repo: cugraph-ops
     <<: *git_defaults
 
+- name: wholegraph
+  path: wholegraph
+  cpp:
+    - name: wholegraph
+      sub_dir: cpp
+      depends: [rmm, raft]
+  python:
+    - name: wholegraph
+      sub_dir: python/pylibwholegraph
+      depends: [rmm, raft]
+  git:
+    repo: wholegraph
+    <<: *git_defaults
+
 - name: cugraph
   path: cugraph
   cpp:


### PR DESCRIPTION
Adds [rapidsai/wholegraph](https://github.com/rapidsai/wholegraph) to `manifest.yaml`.

`wholegraph` depends on:
* `clang-tools=16.0.0` instead of `clang-tools=16.0.6`
* `doxygen=1.8.20` instead of `doxygen=1.9.1`
* `cudnn=8.4` instead of `cudnn=8.8`

Updating those causes the combined env to solve, not sure yet whether it builds.