### PR TITLE
Fix VSCode extensions and setting names

### DIFF
--- a/features/src/llvm/devcontainer-feature.json
+++ b/features/src/llvm/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "LLVM compilers and tools",
   "id": "llvm",
-  "version": "24.2.0",
+  "version": "24.2.2",
   "description": "A feature to install LLVM compilers and tools",
   "options": {
     "version": {
@@ -58,8 +58,8 @@
         "C_Cpp.intelliSenseEngine": "disabled",
         "C_Cpp.configurationWarnings": "disabled",
         "C_Cpp.autoAddFileAssociations": false,
-        "clang-format.fallbackStyle": "none",
-        "clang-format.executable": "/usr/bin/clang-format",
+        "clangFormat.fallbackStyle": "none",
+        "clangFormat.executable": "/usr/bin/clang-format",
         "clangd.arguments": [
           "--log=info",
           "--clang-tidy",

--- a/features/src/mambaforge/devcontainer-feature.json
+++ b/features/src/mambaforge/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Mambaforge",
   "id": "mambaforge",
-  "version": "24.2.0",
+  "version": "24.2.1",
   "description": "A feature to install mambaforge",
   "options": {
     "version": {
@@ -21,22 +21,24 @@
   "customizations": {
     "vscode": {
       "extensions": [
+        "ms-python.autopep8",
+        "ms-python.black-formatter",
+        "ms-python.flake8",
+        "ms-python.mypy-type-checker",
+        "ms-python.pylint",
         "ms-python.python",
         "ms-python.vscode-pylance"
       ],
       "settings": {
-        "python.linting.enabled": true,
+        "autopep8.path": "/tmp/.current-conda-env/bin/autopep8",
+        "black-formatter.path": "/tmp/.current-conda-env/bin/black",
+        "clangd.path": "/tmp/.current-conda-env/bin/clangd",
+        "flake8.path": "/tmp/.current-conda-env/bin/flake8",
+        "mypy-type-checker.path": "/tmp/.current-conda-env/bin/mypy",
+        "pylint.enabled": true,
+        "pylint.path": "/tmp/.current-conda-env/bin/pylint",
         "python.terminal.activateEnvironment": false,
-        "python.defaultInterpreterPath": "/tmp/.current-conda-env/bin/python",
-        "python.formatting.autopep8Path": "/tmp/.current-conda-env/bin/autopep8",
-        "python.formatting.blackPath": "/tmp/.current-conda-env/bin/black",
-        "python.formatting.yapfPath": "/tmp/.current-conda-env/bin/yapf",
-        "python.linting.banditPath": "/tmp/.current-conda-env/bin/bandit",
-        "python.linting.flake8Path": "/tmp/.current-conda-env/bin/flake8",
-        "python.linting.mypyPath": "/tmp/.current-conda-env/bin/mypy",
-        "python.linting.pycodestylePath": "/tmp/.current-conda-env/bin/pycodestyle",
-        "python.linting.pydocstylePath": "/tmp/.current-conda-env/bin/pydocstyle",
-        "python.linting.pylintPath": "/tmp/.current-conda-env/bin/pylint"
+        "python.defaultInterpreterPath": "/tmp/.current-conda-env/bin/python"
       }
     }
   }

--- a/image/.devcontainer/devcontainer.json
+++ b/image/.devcontainer/devcontainer.json
@@ -64,7 +64,8 @@
         "C_Cpp.intelliSenseEngine": "disabled",
         "C_Cpp.configurationWarnings": "disabled",
         "C_Cpp.autoAddFileAssociations": false,
-        "clang-format.fallbackStyle": "none",
+        "clangFormat.fallbackStyle": "none",
+        "extensions.ignoreRecommendations": true,
         "files.associations": {
           "*.cu": "cuda-cpp",
           "*.cuh": "cuda-cpp",


### PR DESCRIPTION
* Install separate extensions for python linting, formatting, etc. (per [Migration to Python Tools Extensions](https://github.com/microsoft/vscode-python/wiki/Migration-to-Python-Tools-Extensions))
* Fix the `clang-format` settings property names
* Ignore extension recommendations