### PR TITLE
Remove -DNVBench_ENABLE_CUPTI=OFF.

### DIFF
--- a/.devcontainer/build-rapids.sh
+++ b/.devcontainer/build-rapids.sh
@@ -47,7 +47,7 @@ build_rapids() {
     (
         echo "building cuDF";
         clean-cudf;
-        build-cudf -DBUILD_BENCHMARKS=ON -DNVBench_ENABLE_CUPTI=OFF --verbose
+        build-cudf -DBUILD_BENCHMARKS=ON --verbose
         sccache -s;
     ) 2>&1 | maybe_write_build_log cudf;
 


### PR DESCRIPTION
The `-DNVBench_ENABLE_CUPTI=OFF` flag is no longer needed because of https://github.com/rapidsai/rapids-cmake/pull/504. NVBench CUPTI support is now disabled by default.