### PR TITLE
Add `cugraph-equivariant` to manifest.yaml

### DIFF
--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -171,6 +171,9 @@ repos:
     - name: cugraph-dgl
       sub_dir: python/cugraph-dgl
       depends: [cugraph]
+    - name: cugraph-equivariant
+      sub_dir: python/cugraph-equivariant
+      depends: [cugraph]
     - name: cugraph_pyg
       sub_dir: python/cugraph-pyg
       depends: [cugraph]


### PR DESCRIPTION
Would be nice to have https://github.com/rapidsai/devcontainers/pull/210 merged before this, so CI can validate `cugraph-equivariant` builds.