### PR TITLE
Fix mambaforge shell history

### DIFF
--- a/features/src/mambaforge/.bashrc
+++ b/features/src/mambaforge/.bashrc
@@ -6,12 +6,12 @@ for default_conda_env_name in ${DEFAULT_CONDA_ENV:-} ${CONDA_DEFAULT_ENV:-} base
         break;
     fi
     # Temporarily allow unbound variables for conda activation.
-    oldstate="$(shopt -po; shopt -p)"; [[ -o errexit ]] && oldstate="${oldstate}; set -e"; set +u;
+    oldstate="$(shopt -po | grep -E '(nounset|verbose|xtrace)')"; set +u;
     if conda activate "${default_conda_env_name}" 2>/dev/null; then
-        { set +vx; } 2>/dev/null; eval "${oldstate}"; unset oldstate;
+        { set +vxo history; } 2>/dev/null; eval "${oldstate}"; unset oldstate;
         break;
     else
-        { set +vx; } 2>/dev/null; eval "${oldstate}"; unset oldstate;
+        { set +vxo history; } 2>/dev/null; eval "${oldstate}"; unset oldstate;
         continue;
     fi
 done

--- a/features/src/mambaforge/devcontainer-feature.json
+++ b/features/src/mambaforge/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Mambaforge",
   "id": "mambaforge",
-  "version": "24.4.1",
+  "version": "24.4.2",
   "description": "A feature to install mambaforge",
   "options": {
     "version": {


### PR DESCRIPTION
The `eval "${oldstate}"` restores all the shell opts, but since it runs in interactive terminals where `set -o history` is enabled, they get written to $HISTFILE. This PR ensures restoring the state doesn't write to $HISTFILE.