### PR TITLE
Fix buildx setup on github runners

### DIFF
--- a/.github/actions/feature-matrix/action.yml
+++ b/.github/actions/feature-matrix/action.yml
@@ -30,18 +30,11 @@ runs:
         files: |
           features/src/**
           features/test/**
-          .github/actions/build-and-test-feature/*
-          .github/actions/free-disk-space/*
-          .github/actions/build-linux-image/*
-          .github/actions/image-matrix/*
-          .github/actions/copy-common-scripts/*
-          .github/actions/get-pr-info/*
-          .github/actions/install-devcontainers-cli/*
-          .github/actions/devcontainer-json/*
-          .github/actions/setup-runner-env/*
-          .github/actions/feature-matrix/*
           .github/workflows/test.yml
+          .github/actions/feature-matrix/action.sh
+          .github/actions/feature-matrix/action.yml
           .github/workflows/build-and-test-feature.yml
+          .github/actions/build-and-test-feature/action.yml
 
     - name: Report changes
       if: inputs.full_matrix != 'true'

--- a/.github/actions/feature-matrix/action.yml
+++ b/.github/actions/feature-matrix/action.yml
@@ -30,11 +30,18 @@ runs:
         files: |
           features/src/**
           features/test/**
+          .github/actions/build-and-test-feature/*
+          .github/actions/free-disk-space/*
+          .github/actions/build-linux-image/*
+          .github/actions/image-matrix/*
+          .github/actions/copy-common-scripts/*
+          .github/actions/get-pr-info/*
+          .github/actions/install-devcontainers-cli/*
+          .github/actions/devcontainer-json/*
+          .github/actions/setup-runner-env/*
+          .github/actions/feature-matrix/*
           .github/workflows/test.yml
-          .github/actions/feature-matrix/action.sh
-          .github/actions/feature-matrix/action.yml
           .github/workflows/build-and-test-feature.yml
-          .github/actions/build-and-test-feature/action.yml
 
     - name: Report changes
       if: inputs.full_matrix != 'true'

--- a/.github/actions/setup-runner-env/action.yml
+++ b/.github/actions/setup-runner-env/action.yml
@@ -9,26 +9,26 @@ runs:
       shell: bash -eo pipefail {0}
       run: echo "${{ toJSON(env) }}"
 
-    - if: env.RUNNER_ENVIRONMENT == 'github-hosted'
+    - if: env.RUNNER_ENVIRONMENT != 'self-hosted'
       name: Free up disk space
       uses: ./.github/actions/free-disk-space
       with:
         tool_cache: "${{ runner.tool_cache }}"
 
-    - if: env.RUNNER_ENVIRONMENT != 'github-hosted'
+    - if: env.RUNNER_ENVIRONMENT == 'self-hosted'
       name: Setup self-hosted runner environment
       shell: bash -eo pipefail {0}
       run: |
         echo "HOME=${{ runner.workspace }}" >> $GITHUB_ENV;
         echo "TMPDIR=${{ runner.temp }}" >> $GITHUB_ENV;
 
-    - if: env.RUNNER_ENVIRONMENT != 'github-hosted'
+    - if: env.RUNNER_ENVIRONMENT == 'self-hosted'
       name: Setup Node.js
       uses: actions/setup-node@v3
       with:
         node-version: '16'
 
-    - if: env.RUNNER_ENVIRONMENT == 'github-hosted'
+    - if: env.RUNNER_ENVIRONMENT != 'self-hosted'
       name: Set up QEMU
       uses: docker/setup-qemu-action@v2
 
@@ -36,14 +36,14 @@ runs:
       shell: bash
       run: docker context create builder
 
-    - if: env.RUNNER_ENVIRONMENT == 'github-hosted'
+    - if: env.RUNNER_ENVIRONMENT != 'self-hosted'
       name: Setup docker buildx on github-hosted runners
       uses: docker/setup-buildx-action@v2
       with:
         buildkitd-flags: --debug
         endpoint: builder
 
-    - if: env.RUNNER_ENVIRONMENT != 'github-hosted'
+    - if: env.RUNNER_ENVIRONMENT == 'self-hosted'
       name: Setup docker buildx on self-hosted runners
       uses: docker/setup-buildx-action@v2
       with:

--- a/.github/actions/setup-runner-env/action.yml
+++ b/.github/actions/setup-runner-env/action.yml
@@ -33,7 +33,15 @@ runs:
       shell: bash
       run: docker context create builder
 
-    - name: Setup docker buildx
+    - if: env.RUNNER_ENVIRONMENT == 'github-hosted'
+      name: Setup docker buildx on github-hosted runners
+      uses: docker/setup-buildx-action@v2
+      with:
+        buildkitd-flags: --debug
+        endpoint: builder
+
+    - if: env.RUNNER_ENVIRONMENT != 'github-hosted'
+      name: Setup docker buildx on self-hosted runners
       uses: docker/setup-buildx-action@v2
       with:
         buildkitd-flags: --debug --config /etc/buildkit/buildkitd.toml

--- a/.github/actions/setup-runner-env/action.yml
+++ b/.github/actions/setup-runner-env/action.yml
@@ -5,7 +5,7 @@ description: Setup self-hosted runner environment
 runs:
   using: composite
   steps:
-      name: Dump env
+    - name: Dump env
       shell: bash -eo pipefail {0}
       run: echo "${{ toJSON(env) }}"
 

--- a/.github/actions/setup-runner-env/action.yml
+++ b/.github/actions/setup-runner-env/action.yml
@@ -5,6 +5,9 @@ description: Setup self-hosted runner environment
 runs:
   using: composite
   steps:
+      name: Dump env
+      shell: bash -eo pipefail {0}
+      run: echo "${{ toJSON(env) }}"
 
     - if: env.RUNNER_ENVIRONMENT == 'github-hosted'
       name: Free up disk space


### PR DESCRIPTION
At some point GitHub must've changed `env.RUNNER_ENV` on github-hosted runners, which broke running CI on PRs to forks, e.g. https://github.com/trxcllnt/devcontainers/pull/10 . This PR re-enables CI runs on PRs to forks.