### PR TITLE
Fix mambaforge shell history (backport #219)

### DIFF
--- a/.github/workflows/build-and-test-feature.yml
+++ b/.github/workflows/build-and-test-feature.yml
@@ -25,6 +25,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.GPUCIBOT_DOCKERHUB_USER }}
+          password: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}
+
       - name: ${{ inputs.name }}
         uses: ./.github/actions/build-and-test-feature
         with:

--- a/.github/workflows/build-test-and-push-linux-image.yml
+++ b/.github/workflows/build-test-and-push-linux-image.yml
@@ -51,6 +51,12 @@ jobs:
           features: "${{ inputs.features }}"
           container_env: "${{ inputs.container_env }}"
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.GPUCIBOT_DOCKERHUB_USER }}
+          password: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}
+
       - name: Build ${{ steps.json.outputs.tag }}-${{ matrix.arch }}
         uses: ./.github/actions/build-linux-image
         with:

--- a/.github/workflows/build-test-and-push-windows-image.yml
+++ b/.github/workflows/build-test-and-push-windows-image.yml
@@ -59,6 +59,12 @@ jobs:
           tag=${version}-cuda${cuda}-cl${cl}-${{ inputs.os }}${{ matrix.edition }}
           EOF
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.GPUCIBOT_DOCKERHUB_USER }}
+          password: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}
+
       - name: Build ${{ steps.info.outputs.tag }}
         uses: ./.github/actions/build-windows-image
         with:
@@ -78,13 +84,6 @@ jobs:
           repo: "${{ steps.info.outputs.repo }}"
           version: "${{ steps.info.outputs.version }}"
           edition: "${{ matrix.edition }}"
-
-      - if: inputs.push == 'true'
-        name: Login to Docker Hub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.GPUCIBOT_DOCKERHUB_USER }}
-          password: ${{ secrets.GPUCIBOT_DOCKERHUB_TOKEN }}
 
       - if: inputs.push == 'true'
         name: Push ${{ steps.info.outputs.tag }}

--- a/features/src/mambaforge/.bashrc
+++ b/features/src/mambaforge/.bashrc
@@ -6,12 +6,12 @@ for default_conda_env_name in ${DEFAULT_CONDA_ENV:-} ${CONDA_DEFAULT_ENV:-} base
         break;
     fi
     # Temporarily allow unbound variables for conda activation.
-    oldstate="$(shopt -po; shopt -p)"; [[ -o errexit ]] && oldstate="${oldstate}; set -e"; set +u;
+    oldstate="$(shopt -po | grep -E '(nounset|verbose|xtrace)')"; set +u;
     if conda activate "${default_conda_env_name}" 2>/dev/null; then
-        { set +vx; } 2>/dev/null; eval "${oldstate}"; unset oldstate;
+        { set +vxo history; } 2>/dev/null; eval "${oldstate}"; unset oldstate;
         break;
     else
-        { set +vx; } 2>/dev/null; eval "${oldstate}"; unset oldstate;
+        { set +vxo history; } 2>/dev/null; eval "${oldstate}"; unset oldstate;
         continue;
     fi
 done

--- a/features/src/mambaforge/devcontainer-feature.json
+++ b/features/src/mambaforge/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Mambaforge",
   "id": "mambaforge",
-  "version": "24.2.2",
+  "version": "24.2.3",
   "description": "A feature to install mambaforge",
   "options": {
     "version": {


### PR DESCRIPTION
Disable history when restoring shell options (backport https://github.com/rapidsai/devcontainers/pull/219 to `branch-24.02`)