### PR TITLE
Requesting a clean cpp build also clears any Jitify cache

### DIFF
--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/cpp-clean.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/cpp-clean.tmpl.sh
@@ -5,6 +5,9 @@ clean_${CPP_LIB}_cpp() {
     set -euo pipefail;
 
     rm -rf ~/${CPP_SRC}/build/latest/*;
+    if test -f "~/.${CPP_LIB}/"; then
+        rm -rf "~/.${CPP_LIB}/"
+    fi
 }
 
 if test -n "${rapids_build_utils_debug:-}"; then


### PR DESCRIPTION
This is needed for libcudf specifically, but written to be generalized in case other projects start using Jitify as well.