### PR TITLE
Fix legacy-editable detection

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.4.5",
+  "version": "24.4.6",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/install.sh
+++ b/features/src/rapids-build-utils/install.sh
@@ -59,6 +59,7 @@ declare -a commands=(
     python-conda-pkg-names
     python-pkg-names
     python-pkg-roots
+    python-uses-scikit-build
     python-uses-scikit-build-core
     query-manifest
     select-cmake-args

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/get-cmake-build-dir.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/get-cmake-build-dir.sh
@@ -45,7 +45,8 @@ get_cmake_build_dir() {
     else
         local -r type="$(rapids-select-cmake-build-type "${OPTS[@]}" "${REST[@]:1}" | tr '[:upper:]' '[:lower:]')";
         local -r cuda="$(grep -o '^[0-9]*.[0-9]*' <<< "${CUDA_VERSION:-${CUDA_VERSION_MAJOR:-12}.${CUDA_VERSION_MINOR:-0}}")";
-        local bin="build/${PYTHON_PACKAGE_MANAGER:+/${PYTHON_PACKAGE_MANAGER}}${cuda:+/cuda-${cuda}}";
+        local bin="build";
+        bin+="${PYTHON_PACKAGE_MANAGER:+/${PYTHON_PACKAGE_MANAGER}}${cuda:+/cuda-${cuda}}";
 
         if test -n "${src:-}" && test -d "${src:-}"; then
             mkdir -p "${src}/${bin}";

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/get-cmake-build-dir.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/get-cmake-build-dir.sh
@@ -36,38 +36,41 @@ get_cmake_build_dir() {
     # shellcheck disable=SC1091
     . devcontainer-utils-debug-output 'rapids_build_utils_debug' 'get-cmake-build-dir';
 
-    if test "${REST[0]:-}" == --; then REST=("${REST[@]:1}"); fi;
+    if test "${REST[0]:-}" == --; then REST=("${REST[@]:1}"); fi
 
-    local bin="build";
     local src="${REST[0]:-}";
-    local -r type="$(rapids-select-cmake-build-type "${OPTS[@]}" "${REST[@]:1}" | tr '[:upper:]' '[:lower:]')";
-    local -r cuda="$(grep -o '^[0-9]*.[0-9]*' <<< "${CUDA_VERSION:-${CUDA_VERSION_MAJOR:-12}.${CUDA_VERSION_MINOR:-0}}")";
 
-    bin+="${PYTHON_PACKAGE_MANAGER:+/${PYTHON_PACKAGE_MANAGER}}${cuda:+/cuda-${cuda}}";
-
-    if test -n "${src:-}" && test -d "${src:-}"; then
-        mkdir -p "${src}/${bin}";
-        if  test -z "${skip_links-}"; then
-            if test -z "${skip_build_type-}" || ! test -L "${src}/${bin}/latest"; then
-                mkdir -p "${src}/${bin}/${type}";
-                cd "${src}/${bin}/" || exit 1;
-                ln -sfn "${type}" latest;
-            fi
-            cd "${src}/build" || exit 1;
-            local component;
-            for component in "${PYTHON_PACKAGE_MANAGER:-}" "${cuda:+cuda-${cuda}}"; do
-                if test -n "${component:-}"; then
-                    ln -sfn "${component}/latest" latest;
-                    cd "${component}" || exit 1;
-                fi
-            done
-        fi
-    fi
-
-    if test -n "${skip_build_type-}"; then
-        echo "${src:+${src}/}${bin}/latest";
+    if test -n "${src}" && rapids-python-uses-scikit-build "${src}"; then
+        echo "${src:+${src}/}$(python -c 'from skbuild import constants; print(constants.CMAKE_BUILD_DIR())')";
     else
-        echo "${src:+${src}/}${bin}/${type}";
+        local -r type="$(rapids-select-cmake-build-type "${OPTS[@]}" "${REST[@]:1}" | tr '[:upper:]' '[:lower:]')";
+        local -r cuda="$(grep -o '^[0-9]*.[0-9]*' <<< "${CUDA_VERSION:-${CUDA_VERSION_MAJOR:-12}.${CUDA_VERSION_MINOR:-0}}")";
+        local bin="build/${PYTHON_PACKAGE_MANAGER:+/${PYTHON_PACKAGE_MANAGER}}${cuda:+/cuda-${cuda}}";
+
+        if test -n "${src:-}" && test -d "${src:-}"; then
+            mkdir -p "${src}/${bin}";
+            if  test -z "${skip_links-}"; then
+                if test -z "${skip_build_type-}" || ! test -L "${src}/${bin}/latest"; then
+                    mkdir -p "${src}/${bin}/${type}";
+                    cd "${src}/${bin}/" || exit 1;
+                    ln -sfn "${type}" latest;
+                fi
+                cd "${src}/build" || exit 1;
+                local component;
+                for component in "${PYTHON_PACKAGE_MANAGER:-}" "${cuda:+cuda-${cuda}}"; do
+                    if test -n "${component:-}"; then
+                        ln -sfn "${component}/latest" latest;
+                        cd "${component}" || exit 1;
+                    fi
+                done
+            fi
+        fi
+
+        if test -n "${skip_build_type-}"; then
+            echo "${src:+${src}/}${bin}/latest";
+        else
+            echo "${src:+${src}/}${bin}/${type}";
+        fi
     fi
 }
 

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/maybe-clean-build-dir.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/maybe-clean-build-dir.sh
@@ -27,12 +27,15 @@ maybe_clean_build_dir() {
 
     local -r bin_dir="$(rapids-get-cmake-build-dir "${OPTS[@]}" "${REST[@]}")";
 
-    case "${G:-Ninja}" in
-        "Unix Makefiles")
-            test -f "${bin_dir}/Makefile" || rm -rf "${bin_dir}";;
-        "Ninja")
-            test -f "${bin_dir}/build.ninja" || rm -rf "${bin_dir}";;
-    esac
+    if test -n "${bin_dir-}" && test -d "${bin_dir}"; then
+        case "${G:-Ninja}" in
+            "Unix Makefiles")
+                test -f "${bin_dir}/Makefile" || rm -rf "${bin_dir}";;
+            "Ninja")
+                test -f "${bin_dir}/build.ninja" || rm -rf "${bin_dir}";;
+        esac
+    fi
+
     echo "${bin_dir}";
 }
 

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/merge-compile-commands-json.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/merge-compile-commands-json.sh
@@ -33,6 +33,11 @@ _list_repo_paths() {
             for ((j=0; j < ${!py_length:-0}; j+=1)); do
                 local py_sub_dir="${repo}_python_${j}_sub_dir";
                 local py_path=~/"${!repo_path:-}${!py_sub_dir:+/${!py_sub_dir}}";
+                # TODO: What are we really checking here? Do we want only
+                # packages built by scikit-build-core, or do we want all
+                # compiled Python packages (by either scikit-build or
+                # scikit-build-core) vs pure Python packages (built by
+                # setuptools)?
                 if rapids-python-uses-scikit-build-core "${py_path}"; then
                     echo "${py_path}";
                 fi

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/merge-compile-commands-json.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/merge-compile-commands-json.sh
@@ -33,12 +33,8 @@ _list_repo_paths() {
             for ((j=0; j < ${!py_length:-0}; j+=1)); do
                 local py_sub_dir="${repo}_python_${j}_sub_dir";
                 local py_path=~/"${!repo_path:-}${!py_sub_dir:+/${!py_sub_dir}}";
-                # TODO: What are we really checking here? Do we want only
-                # packages built by scikit-build-core, or do we want all
-                # compiled Python packages (by either scikit-build or
-                # scikit-build-core) vs pure Python packages (built by
-                # setuptools)?
-                if rapids-python-uses-scikit-build-core "${py_path}"; then
+                if rapids-python-uses-scikit-build "${py_path}" \
+                || rapids-python-uses-scikit-build-core "${py_path}"; then
                     echo "${py_path}";
                 fi
             done

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-uses-scikit-build-core.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-uses-scikit-build-core.sh
@@ -3,4 +3,4 @@
 set -e;
 
 test -f "${1}/pyproject.toml";
-test "scikit_build_core.build" = "$(python -c "import toml; print(toml.load('${1}/pyproject.toml')['build-system']['build-backend'])" 2>/dev/null)";
+test "scikit_build_core.build" = "$(/usr/local/python/current/bin/python -c "import toml; print(toml.load('${1}/pyproject.toml')['build-system']['build-backend'])" 2>/dev/null)";

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-uses-scikit-build.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-uses-scikit-build.sh
@@ -3,4 +3,4 @@
 set -e;
 
 test -f "${1}/pyproject.toml";
-test "True" = "$(/usr/local/python/current/bin/python -c "import toml; print(any('scikit-build-core' not in x and 'scikit-build' in x for x in toml.load('${1}/pyproject.toml')['build-system']['requires']))")";
+test "True" = "$(/usr/local/python/current/bin/python -c "import toml; print(any('scikit-build-core' not in x and 'scikit-build' in x for x in toml.load('${1}/pyproject.toml')['build-system']['requires']))" 2>/dev/null)";

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-uses-scikit-build.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-uses-scikit-build.sh
@@ -3,4 +3,4 @@
 set -e;
 
 test -f "${1}/pyproject.toml";
-test "True" = "$(python -c "import toml; from packaging.requirements import Requirement; print(any(Requirement(require).name == 'scikit-build' for require in toml.load('${1}/pyproject.toml')['build-system']['requires']))" 2>/dev/null)"
+test "True" = "$(/usr/local/python/current/bin/python -c "import toml; print(any('scikit-build-core' not in x and 'scikit-build' in x for x in toml.load('${1}/pyproject.toml')['build-system']['requires']))")";

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-uses-scikit-build.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-uses-scikit-build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -e;
+
+test -f "${1}/pyproject.toml";
+test "True" = "$(python -c "import toml; from packaging.requirements import Requirement; print(any(Requirement(require).name == 'scikit-build' for require in toml.load('${1}/pyproject.toml')['build-system']['requires']))" 2>/dev/null)"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.build.wheel.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.build.wheel.tmpl.sh
@@ -68,8 +68,12 @@ build_${PY_LIB}_python_wheel() {
         $(rapids-select-pip-wheel-args "$@")
     )";
 
-    # TODO: Should this be handling the _skbuild directory from scikit-build differently?
-    if rapids-python-uses-scikit-build-core "${PY_SRC}"; then
+    if rapids-python-uses-scikit-build "${PY_SRC}"; then
+        # Clean the `_skbuild/.../cmake-build` dir if configuration failed before
+        if ! test -d "$(rapids-maybe-clean-build-dir "${cmake_args[@]}" -- "${PY_SRC}")"; then
+            rm -rf "${PY_SRC}/_skbuild";
+        fi
+    elif rapids-python-uses-scikit-build-core "${PY_SRC}"; then
         pip_args+=(-C "build-dir=$(rapids-maybe-clean-build-dir "${cmake_args[@]}" -- "${PY_SRC}")");
     fi
 

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.build.wheel.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.build.wheel.tmpl.sh
@@ -68,6 +68,7 @@ build_${PY_LIB}_python_wheel() {
         $(rapids-select-pip-wheel-args "$@")
     )";
 
+    # TODO: Should this be handling the _skbuild directory from scikit-build differently?
     if rapids-python-uses-scikit-build-core "${PY_SRC}"; then
         pip_args+=(-C "build-dir=$(rapids-maybe-clean-build-dir "${cmake_args[@]}" -- "${PY_SRC}")");
     fi

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.install.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.install.tmpl.sh
@@ -66,10 +66,14 @@ install_${PY_LIB}_python() {
         $(rapids-select-pip-install-args "$@")
     )";
 
+    # TODO: Should this be handling the _skbuild directory from scikit-build differently?
     if rapids-python-uses-scikit-build-core "${PY_SRC}"; then
         pip_args+=(-C "build-dir=$(rapids-maybe-clean-build-dir "${cmake_args[@]}" -- "${PY_SRC}")");
-    elif test ${#editable[@]} -gt 0; then
-        export SETUPTOOLS_ENABLE_FEATURES=legacy-editable;
+    fi
+    if rapids-python-uses-scikit-build "${PY_SRC}"; then
+        if test ${#editable[@]} -gt 0; then
+            export SETUPTOOLS_ENABLE_FEATURES=legacy-editable;
+        fi
     fi
 
     # Put --editable at the end of pip_args

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.install.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.install.tmpl.sh
@@ -66,14 +66,16 @@ install_${PY_LIB}_python() {
         $(rapids-select-pip-install-args "$@")
     )";
 
-    # TODO: Should this be handling the _skbuild directory from scikit-build differently?
-    if rapids-python-uses-scikit-build-core "${PY_SRC}"; then
-        pip_args+=(-C "build-dir=$(rapids-maybe-clean-build-dir "${cmake_args[@]}" -- "${PY_SRC}")");
-    fi
     if rapids-python-uses-scikit-build "${PY_SRC}"; then
+        # Clean the `_skbuild/.../cmake-build` dir if configuration failed before
+        if ! test -d "$(rapids-maybe-clean-build-dir "${cmake_args[@]}" -- "${PY_SRC}")"; then
+            rm -rf "${PY_SRC}/_skbuild";
+        fi
         if test ${#editable[@]} -gt 0; then
             export SETUPTOOLS_ENABLE_FEATURES=legacy-editable;
         fi
+    elif rapids-python-uses-scikit-build-core "${PY_SRC}"; then
+        pip_args+=(-C "build-dir=$(rapids-maybe-clean-build-dir "${cmake_args[@]}" -- "${PY_SRC}")");
     fi
 
     # Put --editable at the end of pip_args

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/update-build-dir-links.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/update-build-dir-links.sh
@@ -46,6 +46,7 @@ update_build_dir_links() {
             for ((j=0; j < ${!py_length:-0}; j+=1)); do
                 local py_sub_dir="${repo}_python_${j}_sub_dir";
                 local py_path=~/"${!repo_path:-}${!py_sub_dir:+/${!py_sub_dir}}";
+                # TODO: Should this also preserve the _skbuild directory for scikit-build projects?
                 if rapids-python-uses-scikit-build-core "${py_path}"; then
                     rapids-get-cmake-build-dir --skip-build-type -- "${py_path}" >/dev/null;
                 fi

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/update-build-dir-links.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/update-build-dir-links.sh
@@ -46,7 +46,6 @@ update_build_dir_links() {
             for ((j=0; j < ${!py_length:-0}; j+=1)); do
                 local py_sub_dir="${repo}_python_${j}_sub_dir";
                 local py_path=~/"${!repo_path:-}${!py_sub_dir:+/${!py_sub_dir}}";
-                # TODO: Should this also preserve the _skbuild directory for scikit-build projects?
                 if rapids-python-uses-scikit-build-core "${py_path}"; then
                     rapids-get-cmake-build-dir --skip-build-type -- "${py_path}" >/dev/null;
                 fi


### PR DESCRIPTION
Currently the devcontainers are setting all non-scikit-build-core builds to use the legacy editable setting. This is problematic for projects that are using setuptools directly (or any other backend other than scikit-build-core) without using scikit-build because legacy editable mode breaks some uses cases. In particular, we currently observe this as the breaking of dask_cudf entrypoints, which are not properly installed in legacy editable mode.

I added a new tool for the detection, but I wasn't sure how exactly we should be changing all the existing use cases so I left some notes. I will need a bit of guidance on what each of those cases should do.