### PR TITLE
Fix `rapids-select-cmake-define` arg parsing

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.4.6",
+  "version": "24.4.7",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/select-cmake-define.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/select-cmake-define.sh
@@ -19,7 +19,7 @@ parse_cmake_define() {
     local val;
     local def="$1"; shift;
 
-    eval "$(devcontainer-utils-parse-args <(echo -e "\n# -D <def>") "$@" <&0)";
+    eval "$(devcontainer-utils-parse-args <(echo -e "\n# -D <def>\n# --D <def>") "$@" <&0)";
 
     # shellcheck disable=SC1091
     . devcontainer-utils-debug-output 'rapids_build_utils_debug' 'select-cmake-define';


### PR DESCRIPTION
Fix arg parsing when `rapids-select-cmake-define` is passed long opts before the short opts, i.e.: 
```shell
rapids-select-cmake-build-type -Wno-dev --prefix /usr -DCMAKE_BUILD_TYPE=Debug
```