### PR TITLE
Add FileCheck to LLVM update-alternatives list.

### DIFF
--- a/features/src/llvm/devcontainer-feature.json
+++ b/features/src/llvm/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "LLVM compilers and tools",
   "id": "llvm",
-  "version": "24.6.0",
+  "version": "24.6.1",
   "description": "A feature to install LLVM compilers and tools",
   "options": {
     "version": {

--- a/features/src/llvm/install.sh
+++ b/features/src/llvm/install.sh
@@ -41,7 +41,7 @@ echo "Installing llvm-${LLVM_VERSION} compilers and tools";
 ./llvm.sh $LLVM_VERSION ${PACKAGES:-all};
 
 if [[ "${PACKAGES:-all}" == "all" ]]; then
-    PACKAGES=("clang" "clangd" "clang++" "clang-format" "clang-tidy" "lldb" "llvm-config" "llvm-cov");
+    PACKAGES=("clang" "clangd" "clang++" "clang-format" "clang-tidy" "lldb" "llvm-config" "llvm-cov" "FileCheck");
 else
     PACKAGES=(${PACKAGES});
 fi


### PR DESCRIPTION
Provides `FileCheck` instead of `FileCheck-N` to devcontainers with the LLVM feature. This allows for use of `FileCheck` when LLVM is detectable rather than needing to parse the version of LLVM to get the name of the utility.