### PR TITLE
Add NVML to the Windows CUDA components list.

### DIFF
--- a/windows/image/installers/install-cuda.ps1
+++ b/windows/image/installers/install-cuda.ps1
@@ -51,9 +51,17 @@ $componentTag = @{
 }[$cudaVersion]
 
 $cudaVersionUrl = "https://developer.download.nvidia.com/compute/cuda/$cudaUri"
-
+$cudaComponents = 
+    "nvcc_$componentTag",
+    "curand_$componentTag",
+    "curand_dev_$componentTag",
+    "cudart_$componentTag",
+    "nvrtc_$componentTag",
+    "nvrtc_dev_$componentTag",
+    "nvml_dev_$componentTag"
+    
 Invoke-WebRequest -Uri "$cudaVersionUrl" -OutFile "./cuda_network.exe" -UseBasicParsing
-Start-Process -Wait -PassThru -FilePath .\cuda_network.exe -ArgumentList "-s nvcc_$componentTag curand_$componentTag curand_dev_$componentTag cudart_$componentTag nvrtc_$componentTag nvrtc_dev_$componentTag"
+Start-Process -Wait -PassThru -FilePath .\cuda_network.exe -ArgumentList "-s $cudaComponents"
 
 $ENV:PATH="$ENV:PATH;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$componentTag\bin"
 $ENV:CUDA_PATH="C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v$componentTag"

--- a/windows/image/installers/install-cuda.ps1
+++ b/windows/image/installers/install-cuda.ps1
@@ -56,6 +56,7 @@ $cudaComponents =
     "curand_$componentTag",
     "curand_dev_$componentTag",
     "cudart_$componentTag",
+    "cupti_$componentTag",
     "nvrtc_$componentTag",
     "nvrtc_dev_$componentTag",
     "nvml_dev_$componentTag"


### PR DESCRIPTION
This is needed for compiling nvbench.

It also moves the array of CUDA components somewhere more accessible to edit.