### PR TITLE
Update rmm in manifest to point to subdirectory

### DIFF
--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -13,7 +13,7 @@ repos:
       sub_dir: ""
   python:
     - name: rmm
-      sub_dir: python
+      sub_dir: python/rmm
       depends: [rmm]
       args: {cmake: -DFIND_RMM_CPP=ON}
 


### PR DESCRIPTION
This PR is necessary for https://github.com/rapidsai/rmm/pull/1526. Unfortunately there's a circular dependency since this repo also builds all RAPIDS repos. I think the best path will be that once the rmm PR is approved and all non-pip-devcontainer CI is passing we can admin-merge that PR, then we can rerun CI on this PR and then merge that one. There will be an interim period when things are broken though.