### PR TITLE
Add libcudf manifest for wheel build in devcontainer

### DIFF
--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -78,6 +78,9 @@ repos:
       sub_dir: cpp/libcudf_kafka
       depends: [cudf]
   python:
+    - name: libcudf
+      sub_dir: python/libcudf
+      depends: [cudf]
     - name: pylibcudf
       sub_dir: python/pylibcudf
       depends: [cudf]


### PR DESCRIPTION
I'm not at all sure that I've done this correctly. This is intended to support local development with a devcontainer for the work in https://github.com/rapidsai/cudf/pull/15483