### PR TITLE
Add support for librmm Python build in devcontainers

### DIFF
--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -12,10 +12,12 @@ repos:
     - name: rmm
       sub_dir: ""
   python:
+    - name: librmm
+      sub_dir: python/librmm
+      depends: [rmm]
     - name: rmm
       sub_dir: python/rmm
       depends: [rmm]
-      args: {cmake: -DFIND_RMM_CPP=ON}
 
 - name: ucxx
   path: ucxx


### PR DESCRIPTION
This adds the librmm Python package to devcontainers. In devcontainer builds, this package build will be a no-op because the C++ library should be built first. Also, this package is not included in the dependency list for any other package, so it shouldn't ever really be needed. It is primarily being added to keep the manifest complete and to ensure that dependency lists will properly filter out the new dependency.