### PR TITLE
libraft also requires librmm

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.6.14",
+  "version": "24.6.15",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -85,7 +85,7 @@ repos:
   python:
     - name: libraft
       sub_dir: python/libraft
-      depends: [raft]
+      depends: [librmm, raft]
     - name: pylibraft
       sub_dir: python/pylibraft
       depends: [raft]


### PR DESCRIPTION
The libraft entry added in #287 needs to also account for the inter-wheel dependency between libraft and librmm.