### PR TITLE
Handle arguments with spaces in `CMAKE_ARGS`

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.6.15",
+  "version": "24.6.16",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.6.17",
+  "version": "24.6.18",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/generate-docstring.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/generate-docstring.sh
@@ -163,7 +163,7 @@ _include_pip_wheel_options\
         local -;
         set -euo pipefail;
         eval "$(_parse_args "$@" <&0)";
-        echo "${ARGS[*]}";
+        echo "${ARGS[*]@Q}";
     }
 
     _parse_args() {

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/pull-repositories.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/pull-repositories.sh
@@ -63,25 +63,28 @@ pull_repositories() {
 
             read -rp "
 ############################################################
-Branch \"${branch}\" $(
-if test -n "${default_branch}"; then
-    echo "and \"${default_branch}\"";
-fi
-) not found in:
+$(
+    test -z "${default_branch:-}" && \
+    echo "Branch \"${branch}\" " || \
+    echo "Branches \"${branch}\" and \"${default_branch}\" "
+)\
+not found in:
 ${remote_info}
 ############################################################
 
 Please enter a branch name to pull (or leave empty to skip): " branch </dev/tty
+
+            if test -z "${branch:-}"; then
+                echo "No alternate branch name supplied, skipping";
+                break;
+            fi
         done
 
         if test -n "${branch:-}"; then
             echo "Pulling ${!repo_name} ${remote}/${branch}...";
             git -C ~/${!repo_path} pull --no-tags "${remote}" "${branch}";
             git -C ~/${!repo_path} submodule update --init --recursive;
-        else
-            echo "No alternate branch name supplied, skipping";
-        fi;
-
+        fi
     done
 }
 

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/cpp.install.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/cpp.install.tmpl.sh
@@ -29,10 +29,11 @@ install_${CPP_LIB}_cpp() {
             comp="";
         fi
         time (
+            local -a cmake_install_args="($(rapids-select-cmake-install-args "${OPTS[@]}"))";
             cmake --install "${CPP_SRC}/${BIN_DIR}/" \
                   --prefix "${prefix}"               \
                   ${comp:+--component "${comp}"}     \
-                  $(rapids-select-cmake-install-args "${OPTS[@]}");
+                  "${cmake_install_args[@]}";
 
             { set +x; } 2>/dev/null; echo -n "lib${CPP_LIB}${component:+ $component} install time:";
         ) 2>&1;

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.build.wheel.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.build.wheel.tmpl.sh
@@ -94,7 +94,7 @@ build_${PY_LIB}_python_wheel() {
         CUDAFLAGS="${cudaflags}"                     \
         CMAKE_GENERATOR="${G:-Ninja}"                \
         PARALLEL_LEVEL="${n_jobs}"                   \
-        CMAKE_ARGS="${cmake_args[*]}"                \
+        CMAKE_ARGS="${cmake_args[*]@Q}"              \
         SKBUILD_BUILD_OPTIONS="${ninja_args[*]}"     \
         SKBUILD_BUILD_TOOL_ARGS="${ninja_args[*]}"   \
         SKBUILD_LOGGING_LEVEL="${v:+INFO}"           \

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.install.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.install.tmpl.sh
@@ -112,7 +112,7 @@ install_${PY_LIB}_python() {
         CUDAFLAGS="${cudaflags}"                     \
         CMAKE_GENERATOR="${G:-Ninja}"                \
         PARALLEL_LEVEL="${n_jobs}"                   \
-        CMAKE_ARGS="${cmake_args[*]}"                \
+        CMAKE_ARGS="${cmake_args[*]@Q}"              \
         SKBUILD_BUILD_OPTIONS="${ninja_args[*]}"     \
         SKBUILD_BUILD_TOOL_ARGS="${ninja_args[*]}"   \
         SKBUILD_LOGGING_LEVEL="${v:+INFO}"           \


### PR DESCRIPTION
Escape quotes so arguments with spaces are handled appropriately in the `CMAKE_ARGS` envvar.