### PR TITLE
Remove libraft and libcugraphops wheels

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.6.18",
+  "version": "24.6.19",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -83,15 +83,14 @@ repos:
       sub_dir: cpp
       depends: [rmm]
   python:
-    - name: libraft
-      sub_dir: python/libraft
-      depends: [raft]
     - name: pylibraft
       sub_dir: python/pylibraft
       depends: [raft]
+      args: {cmake: -DFIND_RAFT_CPP=ON}
     - name: raft-dask
       sub_dir: python/raft-dask
       depends: [ucxx, raft]
+      args: {cmake: -DFIND_RAFT_CPP=ON}
 
 - name: cuvs
   path: cuvs

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -145,9 +145,6 @@ repos:
         cmake: |
           -DCMAKE_CUDA_ARCHITECTURES="${CUDAARCHS}"
   python:
-    - name: libcugraphops
-      sub_dir: libcugraphops_python
-      depends: [cugraph-ops]
     - name: pylibcugraphops
       sub_dir: pylibcugraphops
       depends: [cugraph-ops]


### PR DESCRIPTION
Work on these wheels is temporarily shelved due to libraft not being safe to use simultaneously in both compiled and header-only mode. We'll pick these efforts back up once the raft/cuvs split is complete.