### PR TITLE
temporarily disable passing `SKBUILD_BUILD_TOOL_ARGS`

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.6.19",
+  "version": "24.6.20",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.build.wheel.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.build.wheel.tmpl.sh
@@ -91,12 +91,12 @@ build_${PY_LIB}_python_wheel() {
         local build_type="$(rapids-select-cmake-build-type "${cmake_args_[@]}")";
         local nvcc_append_flags="${NVCC_APPEND_FLAGS:+$NVCC_APPEND_FLAGS }-t=${n_arch}";
 
+        # SKBUILD_BUILD_TOOL_ARGS="${ninja_args[*]}"   \
         CUDAFLAGS="${cudaflags}"                     \
         CMAKE_GENERATOR="${G:-Ninja}"                \
         PARALLEL_LEVEL="${n_jobs}"                   \
         CMAKE_ARGS="${cmake_args[*]@Q}"              \
         SKBUILD_BUILD_OPTIONS="${ninja_args[*]}"     \
-        SKBUILD_BUILD_TOOL_ARGS="${ninja_args[*]}"   \
         SKBUILD_LOGGING_LEVEL="${v:+INFO}"           \
         SKBUILD_INSTALL_STRIP="${strip:+True}"       \
         SKBUILD_CMAKE_VERBOSE="${v:+True}"           \

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.install.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.install.tmpl.sh
@@ -109,12 +109,12 @@ install_${PY_LIB}_python() {
         local build_type="$(rapids-select-cmake-build-type "${cmake_args_[@]}")";
         local nvcc_append_flags="${NVCC_APPEND_FLAGS:+$NVCC_APPEND_FLAGS }-t=${n_arch}";
 
+        # SKBUILD_BUILD_TOOL_ARGS="${ninja_args[*]}"   \
         CUDAFLAGS="${cudaflags}"                     \
         CMAKE_GENERATOR="${G:-Ninja}"                \
         PARALLEL_LEVEL="${n_jobs}"                   \
         CMAKE_ARGS="${cmake_args[*]@Q}"              \
         SKBUILD_BUILD_OPTIONS="${ninja_args[*]}"     \
-        SKBUILD_BUILD_TOOL_ARGS="${ninja_args[*]}"   \
         SKBUILD_LOGGING_LEVEL="${v:+INFO}"           \
         SKBUILD_INSTALL_STRIP="${strip:+True}"       \
         SKBUILD_CMAKE_VERBOSE="${v:+True}"           \


### PR DESCRIPTION
This is causing [an error](https://github.com/scikit-build/scikit-build-core/pull/733/files#r1600760762) in the new scikit-build-core v0.9.4, so disabling it for now.