### PR TITLE
Exclude ninja from conda/pip envs

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.6.20",
+  "version": "24.6.21",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-dependencies.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-dependencies.sh
@@ -44,12 +44,20 @@ make_conda_dependencies() {
 
     local -a _exclude=(ninja);
     local exc; for exc in "${exclude[@]}"; do
-        _exclude+=(-f "${exc}");
+        if test -f "${exc}"; then
+            _exclude+=(-f "${exc}");
+        else
+            _exclude+=("${exc}");
+        fi
     done
 
     local -a _include=();
     local inc; for inc in "${include[@]}"; do
-        _include+=(-f "${inc}");
+        if test -r "${inc}"; then
+            _include+=(-f "${inc}");
+        else
+            _include+=("${inc}");
+        fi
     done
 
     local cuda_version="${CUDA_VERSION:-${CUDA_VERSION_MAJOR:-12}.${CUDA_VERSION_MINOR:-0}}";

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-dependencies.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-dependencies.sh
@@ -42,7 +42,7 @@ make_conda_dependencies() {
     test ${#include[@]} -eq 0 && include=();
     test ${#key[@]} -eq 0 && key=(all);
 
-    local -a _exclude=();
+    local -a _exclude=(ninja);
     local exc; for exc in "${exclude[@]}"; do
         _exclude+=(-f "${exc}");
     done

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-pip-dependencies.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-pip-dependencies.sh
@@ -43,7 +43,7 @@ make_pip_dependencies() {
     test ${#key[@]} -eq 0 && key=(py_build py_run py_test all);
     test ${#requirement[@]} -eq 0 && requirement=();
 
-    local -a _exclude=();
+    local -a _exclude=(ninja);
     local exc; for exc in "${exclude[@]}"; do
         _exclude+=(-f "${exc}");
     done

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-pip-dependencies.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-pip-dependencies.sh
@@ -45,12 +45,20 @@ make_pip_dependencies() {
 
     local -a _exclude=(ninja);
     local exc; for exc in "${exclude[@]}"; do
-        _exclude+=(-f "${exc}");
+        if test -r "${exc}"; then
+            _exclude+=(-f "${exc}");
+        else
+            _exclude+=("${exc}");
+        fi
     done
 
     local -a _include=();
     local inc; for inc in "${include[@]}"; do
-        _include+=(-f "${inc}");
+        if test -r "${inc}"; then
+            _include+=(-f "${inc}");
+        else
+            _include+=("${inc}");
+        fi
     done
 
     local cuda_version="${CUDA_VERSION:-${CUDA_VERSION_MAJOR:-12}.${CUDA_VERSION_MINOR:-0}}";


### PR DESCRIPTION
Exclude ninja from conda/pip because it doesn't kill child processes. Use the ninja already in the container.