### PR TITLE
remove spaces between -G and the generator name

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.6.20",
+  "version": "24.6.21",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/cpp.configure.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/cpp.configure.tmpl.sh
@@ -39,7 +39,7 @@ configure_${CPP_LIB}_cpp() {
     . devcontainer-utils-debug-output 'rapids_build_utils_debug' 'configure-all configure-${NAME} configure-${CPP_LIB}-cpp';
 
     local -a cmake_args="(
-        -G \"${G:-Ninja}\"
+        -G\"${G:-Ninja}\"
         ${cmake_args_[*]@Q}
         ${CPP_DEPS}
         ${v:+--log-level=VERBOSE}

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.build.wheel.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.build.wheel.tmpl.sh
@@ -45,7 +45,7 @@ build_${PY_LIB}_python_wheel() {
     . devcontainer-utils-debug-output 'rapids_build_utils_debug' 'build-all build-${NAME} build-${PY_LIB}-python build-${PY_LIB}-python-wheel';
 
     local -a cmake_args="(
-        -G \"${G:-Ninja}\"
+        -G\"${G:-Ninja}\"
         ${cmake_args_[*]@Q}
         ${CPP_DEPS}
         ${v:+--log-level=VERBOSE}

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.install.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.install.tmpl.sh
@@ -45,7 +45,7 @@ install_${PY_LIB}_python() {
     . devcontainer-utils-debug-output 'rapids_build_utils_debug' 'build-all build-${NAME} build-${PY_LIB}-python build-${PY_LIB}-python-editable install-all install-${NAME} install-${PY_LIB}-python';
 
     local -a cmake_args="(
-        -G \"${G:-Ninja}\"
+        -G\"${G:-Ninja}\"
         ${cmake_args_[*]@Q}
         ${CPP_DEPS}
         ${v:+--log-level=VERBOSE}


### PR DESCRIPTION
Works around scikit-build issue https://github.com/scikit-build/scikit-build-core/pull/748