### PR TITLE
resolve file_key deprecation warning from rapids-dependency-file-generator

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.8.3",
+  "version": "24.8.5",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-dependencies.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-dependencies.sh
@@ -85,7 +85,7 @@ make_conda_dependencies() {
                     conda_env_yamls+=("${file}");
                     generate_env_yaml                                                         \
                         "${file}"                                                             \
-                        --file_key "${repo_keys[$keyi]}"                                      \
+                        --file-key "${repo_keys[$keyi]}"                                      \
                         --output conda                                                        \
                         --config ~/"${!repo_path}/dependencies.yaml"                          \
                         --matrix "arch=$(uname -m);cuda=${cuda_version};py=${python_version}" \
@@ -108,7 +108,7 @@ make_conda_dependencies() {
                     conda_env_yamls+=("${file}");
                     generate_env_yaml                                                         \
                         "${file}"                                                             \
-                        --file_key "${repo_keys[$keyi]}"                                      \
+                        --file-key "${repo_keys[$keyi]}"                                      \
                         --output conda                                                        \
                         --config ~/"${!repo_path}/dependencies.yaml"                          \
                         --matrix "arch=$(uname -m);cuda=${cuda_version};py=${python_version}" \

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-pip-dependencies.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-pip-dependencies.sh
@@ -89,7 +89,7 @@ make_pip_dependencies() {
                     pip_reqs_txts+=("${file}");
                     generate_requirements                                                     \
                         "${file}"                                                             \
-                        --file_key "${repo_keys[$keyi]}"                                      \
+                        --file-key "${repo_keys[$keyi]}"                                      \
                         --output requirements                                                 \
                         --config ~/"${!repo_path}/dependencies.yaml"                          \
                         --matrix "arch=$(uname -m);cuda=${cuda_version};py=${python_version}" \
@@ -112,7 +112,7 @@ make_pip_dependencies() {
                     pip_reqs_txts+=("${file}");
                     generate_requirements                                                     \
                         "${file}"                                                             \
-                        --file_key "${repo_keys[$keyi]}"                                      \
+                        --file-key "${repo_keys[$keyi]}"                                      \
                         --output requirements                                                 \
                         --config ~/"${!repo_path}/dependencies.yaml"                          \
                         --matrix "arch=$(uname -m);cuda=${cuda_version};py=${python_version}" \


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/dependency-file-generator/issues/89

Resolves this warning coming from `rapids-dependency-file-generator`.

> /opt/conda/lib/python3.9/site-packages/rapids_dependency_file_generator/cli.py:98: UserWarning: The use of --file_key is deprecated. Use -f or --file-key instead.

## Notes for Reviewers

This warning has been in there for a little over 2 months, since https://github.com/rapidsai/dependency-file-generator/pull/71 (which was in `rapids-dependency-file-generator==1.13.0`).

I think it should be fine to make this change here, as `rapids-dependency-file-generator` is reinstalled at startup.

https://github.com/rapidsai/devcontainers/blob/bff06939d44479ae1f63c3f128881d6d533de99c/features/src/rapids-build-utils/install.sh#L42