### PR TITLE
update make-*-dependences scripts to work with no projects

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.8.10",
+  "version": "24.8.11",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.8.9",
+  "version": "24.8.10",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-dependencies.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-dependencies.sh
@@ -70,6 +70,23 @@ make_conda_dependencies() {
 
         if [ -f ~/"${!repo_path}/dependencies.yaml" ]; then
 
+            echo "Generating ${!repo_name}'s repo conda env yml" 1>&2;
+
+            local repo_keys=("${key[@]}");
+            local keyi;
+
+            for ((keyi=0; keyi < ${#repo_keys[@]}; keyi+=1)); do
+                local file="/tmp/${!repo_name}.${repo_keys[$keyi]}.env.yaml";
+                conda_env_yamls+=("${file}");
+                generate_env_yaml                                                         \
+                    "${file}"                                                             \
+                    --file-key "${repo_keys[$keyi]}"                                      \
+                    --output conda                                                        \
+                    --config ~/"${!repo_path}/dependencies.yaml"                          \
+                    --matrix "arch=$(uname -m);cuda=${cuda_version};py=${python_version}" \
+                    ;
+            done
+
             local cpp_length="${repo}_cpp_length";
 
             for ((j=0; j < ${!cpp_length:-0}; j+=1)); do
@@ -77,7 +94,7 @@ make_conda_dependencies() {
 
                 echo "Generating lib${!cpp_name}'s conda env yml" 1>&2;
 
-                local repo_keys=("${key[@]}" "${key[@]/%/_lib${!cpp_name//"-"/"_"}}");
+                local repo_keys=("${key[@]/%/_lib${!cpp_name//"-"/"_"}}");
                 local keyi;
 
                 for ((keyi=0; keyi < ${#repo_keys[@]}; keyi+=1)); do
@@ -100,7 +117,7 @@ make_conda_dependencies() {
 
                 echo "Generating ${!py_name}'s conda env yml" 1>&2;
 
-                local repo_keys=("${key[@]}" "${key[@]/%/_${!py_name//"-"/"_"}}");
+                local repo_keys=("${key[@]/%/_${!py_name//"-"/"_"}}");
                 local keyi;
 
                 for ((keyi=0; keyi < ${#repo_keys[@]}; keyi+=1)); do

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-pip-dependencies.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-pip-dependencies.sh
@@ -74,6 +74,23 @@ make_pip_dependencies() {
 
         if [ -f ~/"${!repo_path}/dependencies.yaml" ]; then
 
+            echo "Generating ${!repo_name}'s repo requirements.txt" 1>&2;
+
+            local repo_keys=("${key[@]}");
+            local keyi;
+
+            for ((keyi=0; keyi < ${#repo_keys[@]}; keyi+=1)); do
+                local file="/tmp/${!repo_name}.${repo_keys[$keyi]}.requirements.txt";
+                pip_reqs_txts+=("${file}");
+                generate_requirements                                                     \
+                    "${file}"                                                             \
+                    --file-key "${repo_keys[$keyi]}"                                      \
+                    --output requirements                                                 \
+                    --config ~/"${!repo_path}/dependencies.yaml"                          \
+                    --matrix "arch=$(uname -m);cuda=${cuda_version};py=${python_version}" \
+                    ;
+            done
+
             local cpp_length="${repo}_cpp_length";
 
             for ((j=0; j < ${!cpp_length:-0}; j+=1)); do
@@ -81,7 +98,7 @@ make_pip_dependencies() {
 
                 echo "Generating lib${!cpp_name}'s requirements.txt" 1>&2;
 
-                local repo_keys=("${key[@]}" "${key[@]/%/_lib${!cpp_name//"-"/"_"}}");
+                local repo_keys=("${key[@]/%/_lib${!cpp_name//"-"/"_"}}");
                 local keyi;
 
                 for ((keyi=0; keyi < ${#repo_keys[@]}; keyi+=1)); do
@@ -104,7 +121,7 @@ make_pip_dependencies() {
 
                 echo "Generating ${!py_name}'s requirements.txt" 1>&2;
 
-                local repo_keys=("${key[@]}" "${key[@]/%/_${!py_name//"-"/"_"}}");
+                local repo_keys=("${key[@]/%/_${!py_name//"-"/"_"}}");
                 local keyi;
 
                 for ((keyi=0; keyi < ${#repo_keys[@]}; keyi+=1)); do


### PR DESCRIPTION
Updates the dependency generation scripts to work when there is no python or cpp projects available. This is useful for the morpheus examples repository, since it depends on and extends the morpheus dependencies, but does not provide a python or cpp project of it's own.