### PR TITLE
Workaround devcontainer/features/common-utils PS1 messiness

### DIFF
--- a/features/common/install.sh
+++ b/features/common/install.sh
@@ -58,6 +58,7 @@ EOF
 # shellcheck disable=SC2016
 for_each_user_bashrc '
 if [[ "$(grep -qE "^__bash_prompt\(\) \{$" "$0"; echo $?)" == 0 ]]; then
+    sed -i "s/\${BRANCH}/\${BRANCH:-}/g" "$0";
     sed -i "s/\${GITHUB_USER}/\${GITHUB_USER:-}/g" "$0";
 fi
 ';

--- a/features/src/cccl-dev/common/install.sh
+++ b/features/src/cccl-dev/common/install.sh
@@ -58,6 +58,7 @@ EOF
 # shellcheck disable=SC2016
 for_each_user_bashrc '
 if [[ "$(grep -qE "^__bash_prompt\(\) \{$" "$0"; echo $?)" == 0 ]]; then
+    sed -i "s/\${BRANCH}/\${BRANCH:-}/g" "$0";
     sed -i "s/\${GITHUB_USER}/\${GITHUB_USER:-}/g" "$0";
 fi
 ';

--- a/features/src/cccl-dev/devcontainer-feature.json
+++ b/features/src/cccl-dev/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA CCCL development utilities",
   "id": "cccl-dev",
-  "version": "24.8.0",
+  "version": "24.8.1",
   "description": "A feature to install NVIDIA CCCL development utilities",
   "options": {
     "litVersion": {

--- a/features/src/cmake/common/install.sh
+++ b/features/src/cmake/common/install.sh
@@ -58,6 +58,7 @@ EOF
 # shellcheck disable=SC2016
 for_each_user_bashrc '
 if [[ "$(grep -qE "^__bash_prompt\(\) \{$" "$0"; echo $?)" == 0 ]]; then
+    sed -i "s/\${BRANCH}/\${BRANCH:-}/g" "$0";
     sed -i "s/\${GITHUB_USER}/\${GITHUB_USER:-}/g" "$0";
 fi
 ';

--- a/features/src/cmake/devcontainer-feature.json
+++ b/features/src/cmake/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "CMake",
   "id": "cmake",
-  "version": "24.8.0",
+  "version": "24.8.1",
   "description": "A feature to install CMake",
   "options": {
     "version": {

--- a/features/src/cuda/common/install.sh
+++ b/features/src/cuda/common/install.sh
@@ -58,6 +58,7 @@ EOF
 # shellcheck disable=SC2016
 for_each_user_bashrc '
 if [[ "$(grep -qE "^__bash_prompt\(\) \{$" "$0"; echo $?)" == 0 ]]; then
+    sed -i "s/\${BRANCH}/\${BRANCH:-}/g" "$0";
     sed -i "s/\${GITHUB_USER}/\${GITHUB_USER:-}/g" "$0";
 fi
 ';

--- a/features/src/cuda/devcontainer-feature.json
+++ b/features/src/cuda/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "CUDA Toolkit",
   "id": "cuda",
-  "version": "24.8.0",
+  "version": "24.8.1",
   "description": "A feature to install the NVIDIA CUDA Toolkit",
   "options": {
     "version": {

--- a/features/src/gcc/common/install.sh
+++ b/features/src/gcc/common/install.sh
@@ -58,6 +58,7 @@ EOF
 # shellcheck disable=SC2016
 for_each_user_bashrc '
 if [[ "$(grep -qE "^__bash_prompt\(\) \{$" "$0"; echo $?)" == 0 ]]; then
+    sed -i "s/\${BRANCH}/\${BRANCH:-}/g" "$0";
     sed -i "s/\${GITHUB_USER}/\${GITHUB_USER:-}/g" "$0";
 fi
 ';

--- a/features/src/gcc/devcontainer-feature.json
+++ b/features/src/gcc/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "GCC",
   "id": "gcc",
-  "version": "24.8.0",
+  "version": "24.8.1",
   "description": "A feature to install gcc",
   "options": {
     "version": {

--- a/features/src/gitlab-cli/common/install.sh
+++ b/features/src/gitlab-cli/common/install.sh
@@ -58,6 +58,7 @@ EOF
 # shellcheck disable=SC2016
 for_each_user_bashrc '
 if [[ "$(grep -qE "^__bash_prompt\(\) \{$" "$0"; echo $?)" == 0 ]]; then
+    sed -i "s/\${BRANCH}/\${BRANCH:-}/g" "$0";
     sed -i "s/\${GITHUB_USER}/\${GITHUB_USER:-}/g" "$0";
 fi
 ';

--- a/features/src/gitlab-cli/devcontainer-feature.json
+++ b/features/src/gitlab-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "gitlab-cli",
-  "version": "24.8.0",
+  "version": "24.8.1",
   "name": "GitLab CLI",
   "documentationURL": "https://github.com/rapidsai/devcontainers/features/tree/main/src/gitlab-cli",
   "description": "Installs the GitLab CLI. Auto-detects latest version and installs needed dependencies.",

--- a/features/src/llvm/common/install.sh
+++ b/features/src/llvm/common/install.sh
@@ -58,6 +58,7 @@ EOF
 # shellcheck disable=SC2016
 for_each_user_bashrc '
 if [[ "$(grep -qE "^__bash_prompt\(\) \{$" "$0"; echo $?)" == 0 ]]; then
+    sed -i "s/\${BRANCH}/\${BRANCH:-}/g" "$0";
     sed -i "s/\${GITHUB_USER}/\${GITHUB_USER:-}/g" "$0";
 fi
 ';

--- a/features/src/llvm/devcontainer-feature.json
+++ b/features/src/llvm/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "LLVM compilers and tools",
   "id": "llvm",
-  "version": "24.8.0",
+  "version": "24.8.1",
   "description": "A feature to install LLVM compilers and tools",
   "options": {
     "version": {

--- a/features/src/mambaforge/common/install.sh
+++ b/features/src/mambaforge/common/install.sh
@@ -58,6 +58,7 @@ EOF
 # shellcheck disable=SC2016
 for_each_user_bashrc '
 if [[ "$(grep -qE "^__bash_prompt\(\) \{$" "$0"; echo $?)" == 0 ]]; then
+    sed -i "s/\${BRANCH}/\${BRANCH:-}/g" "$0";
     sed -i "s/\${GITHUB_USER}/\${GITHUB_USER:-}/g" "$0";
 fi
 ';

--- a/features/src/mambaforge/devcontainer-feature.json
+++ b/features/src/mambaforge/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Mambaforge",
   "id": "mambaforge",
-  "version": "24.8.0",
+  "version": "24.8.1",
   "description": "A feature to install mambaforge",
   "options": {
     "version": {

--- a/features/src/ninja/common/install.sh
+++ b/features/src/ninja/common/install.sh
@@ -58,6 +58,7 @@ EOF
 # shellcheck disable=SC2016
 for_each_user_bashrc '
 if [[ "$(grep -qE "^__bash_prompt\(\) \{$" "$0"; echo $?)" == 0 ]]; then
+    sed -i "s/\${BRANCH}/\${BRANCH:-}/g" "$0";
     sed -i "s/\${GITHUB_USER}/\${GITHUB_USER:-}/g" "$0";
 fi
 ';

--- a/features/src/ninja/devcontainer-feature.json
+++ b/features/src/ninja/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Ninja build",
   "id": "ninja",
-  "version": "24.8.0",
+  "version": "24.8.1",
   "description": "A feature to install ninja-build",
   "options": {
     "version": {

--- a/features/src/nvhpc/common/install.sh
+++ b/features/src/nvhpc/common/install.sh
@@ -58,6 +58,7 @@ EOF
 # shellcheck disable=SC2016
 for_each_user_bashrc '
 if [[ "$(grep -qE "^__bash_prompt\(\) \{$" "$0"; echo $?)" == 0 ]]; then
+    sed -i "s/\${BRANCH}/\${BRANCH:-}/g" "$0";
     sed -i "s/\${GITHUB_USER}/\${GITHUB_USER:-}/g" "$0";
 fi
 ';

--- a/features/src/nvhpc/devcontainer-feature.json
+++ b/features/src/nvhpc/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVHPC SDK",
   "id": "nvhpc",
-  "version": "24.8.1",
+  "version": "24.8.2",
   "description": "A feature to install the NVHPC SDK",
   "options": {
     "version": {

--- a/features/src/oneapi/common/install.sh
+++ b/features/src/oneapi/common/install.sh
@@ -58,6 +58,7 @@ EOF
 # shellcheck disable=SC2016
 for_each_user_bashrc '
 if [[ "$(grep -qE "^__bash_prompt\(\) \{$" "$0"; echo $?)" == 0 ]]; then
+    sed -i "s/\${BRANCH}/\${BRANCH:-}/g" "$0";
     sed -i "s/\${GITHUB_USER}/\${GITHUB_USER:-}/g" "$0";
 fi
 ';

--- a/features/src/oneapi/devcontainer-feature.json
+++ b/features/src/oneapi/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Intel oneapi toolchain",
   "id": "oneapi",
-  "version": "24.8.0",
+  "version": "24.8.1",
   "description": "A feature to install the Intel oneapi toolchain",
   "options": {
     "version": {

--- a/features/src/openmpi/common/install.sh
+++ b/features/src/openmpi/common/install.sh
@@ -58,6 +58,7 @@ EOF
 # shellcheck disable=SC2016
 for_each_user_bashrc '
 if [[ "$(grep -qE "^__bash_prompt\(\) \{$" "$0"; echo $?)" == 0 ]]; then
+    sed -i "s/\${BRANCH}/\${BRANCH:-}/g" "$0";
     sed -i "s/\${GITHUB_USER}/\${GITHUB_USER:-}/g" "$0";
 fi
 ';

--- a/features/src/openmpi/devcontainer-feature.json
+++ b/features/src/openmpi/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "OpenMPI",
   "id": "openmpi",
-  "version": "24.8.0",
+  "version": "24.8.1",
   "description": "A feature to install OpenMPI with optional CUDA and UCX support",
   "options": {
     "version": {

--- a/features/src/rapids-build-utils/common/install.sh
+++ b/features/src/rapids-build-utils/common/install.sh
@@ -58,6 +58,7 @@ EOF
 # shellcheck disable=SC2016
 for_each_user_bashrc '
 if [[ "$(grep -qE "^__bash_prompt\(\) \{$" "$0"; echo $?)" == 0 ]]; then
+    sed -i "s/\${BRANCH}/\${BRANCH:-}/g" "$0";
     sed -i "s/\${GITHUB_USER}/\${GITHUB_USER:-}/g" "$0";
 fi
 ';

--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.8.11",
+  "version": "24.8.12",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rust/common/install.sh
+++ b/features/src/rust/common/install.sh
@@ -58,6 +58,7 @@ EOF
 # shellcheck disable=SC2016
 for_each_user_bashrc '
 if [[ "$(grep -qE "^__bash_prompt\(\) \{$" "$0"; echo $?)" == 0 ]]; then
+    sed -i "s/\${BRANCH}/\${BRANCH:-}/g" "$0";
     sed -i "s/\${GITHUB_USER}/\${GITHUB_USER:-}/g" "$0";
 fi
 ';

--- a/features/src/rust/devcontainer-feature.json
+++ b/features/src/rust/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "rust",
-  "version": "24.8.0",
+  "version": "24.8.1",
   "name": "Rust",
   "documentationURL": "https://github.com/rapidsai/devcontainers/features/tree/main/src/rust",
   "description": "Installs Rust, common Rust utilities, and their required dependencies",

--- a/features/src/sccache/common/install.sh
+++ b/features/src/sccache/common/install.sh
@@ -58,6 +58,7 @@ EOF
 # shellcheck disable=SC2016
 for_each_user_bashrc '
 if [[ "$(grep -qE "^__bash_prompt\(\) \{$" "$0"; echo $?)" == 0 ]]; then
+    sed -i "s/\${BRANCH}/\${BRANCH:-}/g" "$0";
     sed -i "s/\${GITHUB_USER}/\${GITHUB_USER:-}/g" "$0";
 fi
 ';

--- a/features/src/sccache/devcontainer-feature.json
+++ b/features/src/sccache/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "sccache",
   "id": "sccache",
-  "version": "24.8.0",
+  "version": "24.8.1",
   "description": "A feature to install sccache",
   "options": {
     "version": {

--- a/features/src/ucx/common/install.sh
+++ b/features/src/ucx/common/install.sh
@@ -58,6 +58,7 @@ EOF
 # shellcheck disable=SC2016
 for_each_user_bashrc '
 if [[ "$(grep -qE "^__bash_prompt\(\) \{$" "$0"; echo $?)" == 0 ]]; then
+    sed -i "s/\${BRANCH}/\${BRANCH:-}/g" "$0";
     sed -i "s/\${GITHUB_USER}/\${GITHUB_USER:-}/g" "$0";
 fi
 ';

--- a/features/src/ucx/devcontainer-feature.json
+++ b/features/src/ucx/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "UCX",
   "id": "ucx",
-  "version": "24.8.1",
+  "version": "24.8.2",
   "description": "A feature to install UCX",
   "options": {
     "version": {

--- a/features/src/utils/common/install.sh
+++ b/features/src/utils/common/install.sh
@@ -58,6 +58,7 @@ EOF
 # shellcheck disable=SC2016
 for_each_user_bashrc '
 if [[ "$(grep -qE "^__bash_prompt\(\) \{$" "$0"; echo $?)" == 0 ]]; then
+    sed -i "s/\${BRANCH}/\${BRANCH:-}/g" "$0";
     sed -i "s/\${GITHUB_USER}/\${GITHUB_USER:-}/g" "$0";
 fi
 ';

--- a/features/src/utils/devcontainer-feature.json
+++ b/features/src/utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "devcontainer-utils",
   "id": "utils",
-  "version": "24.8.5",
+  "version": "24.8.6",
   "description": "A feature to install RAPIDS devcontainer utility scripts",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"


### PR DESCRIPTION
Be resilient to the `$BRANCH` variable being undefined in the [PS1 string](https://github.com/devcontainers/features/blob/0356cbb046e3bac9ecff76ac3624178681592cff/src/common-utils/scripts/bash_theme_snippet.sh#L9-L16) from `devcontainers/features/common-utils` and throwing in contexts where shellopt -u is set.