### PR TITLE
add UCX 1.17.0 support

### DIFF
--- a/features/src/ucx/devcontainer-feature.json
+++ b/features/src/ucx/devcontainer-feature.json
@@ -1,13 +1,14 @@
 {
   "name": "UCX",
   "id": "ucx",
-  "version": "24.8.2",
+  "version": "24.8.3",
   "description": "A feature to install UCX",
   "options": {
     "version": {
       "type": "string",
       "proposals": [
         "latest",
+        "1.17.0",
         "1.16.0",
         "1.15.0",
         "1.14.1"

--- a/matrix.yml
+++ b/matrix.yml
@@ -36,7 +36,7 @@ x-nvhpc-env: &nvhpc_env {CC: "nvc", CXX: "nvc++"}
 
 x-mambaforge: &conda { name: "mambaforge" }
 x-python: &python { name: "ghcr.io/devcontainers/features/python:1", version: "os-provided", installTools: "false", hide: true }
-x-ucx-rapids: &ucx_rapids {name: "ucx", version: "1.15.0"}
+x-ucx-rapids: &ucx_rapids {name: "ucx", version: "1.17.0"}
 x-openmpi: &openmpi {name: "openmpi"}
 
 x-cccl-dev: &cccl_dev { name: "cccl-dev", hide: true }


### PR DESCRIPTION
contributes to https://github.com/rapidsai/build-planning/issues/77

Adds support for UCX 1.17.0.

## Notes for Reviewers

I'll follow this up with changes to use UCX 1.17.0 in the devcontainers for relevant RAPIDS repos (e.g. those in the list of PRs linked at #273).