### PR TITLE
Disable CUDA driver requirement.

### DIFF
--- a/features/src/cuda/devcontainer-feature.json
+++ b/features/src/cuda/devcontainer-feature.json
@@ -133,7 +133,8 @@
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env",
     "NVIDIA_VISIBLE_DEVICES": "all",
-    "NVIDIA_DRIVER_CAPABILITIES": "all"
+    "NVIDIA_DRIVER_CAPABILITIES": "all",
+    "NVIDIA_DISABLE_REQUIRE": "true"
   },
   "capAdd": [
     "SYS_PTRACE"

--- a/features/src/cuda/devcontainer-feature.json
+++ b/features/src/cuda/devcontainer-feature.json
@@ -133,8 +133,7 @@
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env",
     "NVIDIA_VISIBLE_DEVICES": "all",
-    "NVIDIA_DRIVER_CAPABILITIES": "all",
-    "NVIDIA_DISABLE_REQUIRE": "true"
+    "NVIDIA_DRIVER_CAPABILITIES": "all"
   },
   "capAdd": [
     "SYS_PTRACE"

--- a/image/.devcontainer/devcontainer.json
+++ b/image/.devcontainer/devcontainer.json
@@ -8,7 +8,10 @@
   },
   "remoteUser": "coder",
   "containerUser": "root",
-  "containerEnv": { "LANG": "${localEnv:LANG:en_US.UTF-8}" },
+  "containerEnv": {
+    "LANG": "${localEnv:LANG:en_US.UTF-8}",
+    "NVIDIA_DISABLE_REQUIRE": "true"
+  },
   "workspaceFolder": "/home/coder",
   "features": {
     "ghcr.io/devcontainers/features/common-utils:2": {


### PR DESCRIPTION
This PR disables CUDA driver version compatibility checks. It doesn't seem like the container is working as intended, because driver 535 (LTS) is failing with CUDA 12.5. This is discussed further in https://github.com/rapidsai/devcontainers/pull/332.
