### PR TITLE
Pin to `features/git:1.3.0` for Ubuntu18.04

### DIFF
--- a/.github/actions/devcontainer-json/action.sh
+++ b/.github/actions/devcontainer-json/action.sh
@@ -28,7 +28,7 @@ const json = JSON.parse(readFileSync('image/.devcontainer/devcontainer.json'));
 
 json.build.args.BASE = '${os}';
 json.build.args.RAPIDS_VERSION = '${VERSION}';
-json.containerEnv = ${container_env} || undefined;
+json.containerEnv = Object.assign(json.containerEnv || {}, ${container_env} || {});
 
 const dups = {};
 

--- a/features/src/llvm/devcontainer-feature.json
+++ b/features/src/llvm/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "LLVM compilers and tools",
   "id": "llvm",
-  "version": "24.8.1",
+  "version": "24.8.2",
   "description": "A feature to install LLVM compilers and tools",
   "options": {
     "version": {

--- a/features/src/llvm/llvm.sh
+++ b/features/src/llvm/llvm.sh
@@ -124,19 +124,28 @@ if [ ! ${LLVM_VERSION_PATTERNS[$LLVM_VERSION]+_} ]; then
     exit 3
 fi
 
-LLVM_VERSION_STRING=${LLVM_VERSION_PATTERNS[$LLVM_VERSION]}
+LLVM_VERSION_STRING="${LLVM_VERSION_PATTERNS[$LLVM_VERSION]}"
 
 # join the repository name
 if [[ -n "${CODENAME}" ]]; then
 
-    if ! curl -fsSL "https://apt.llvm.org/${CODENAME}/dists/llvm-toolchain${LINKNAME}${LLVM_VERSION_STRING}/Release" >/dev/null 2>&1; then
-        LLVM_VERSION_STRING="";
-    fi
+    retry_count=0;
+
+    while ! wget --no-hsts -q --method=HEAD \
+            "${BASE_URL}/${CODENAME}/dists/llvm-toolchain${LINKNAME}${LLVM_VERSION_PATTERNS[$LLVM_VERSION]}/Release" >/dev/null 2>&1; do
+        if test $(( retry_count++ )) -ge 5; then
+            LLVM_VERSION_STRING=
+            break;
+        fi
+        sleep_time=$((retry_count * 5))
+        echo "Attempt $retry_count failed! Trying again in $sleep_time seconds..."
+        sleep $sleep_time
+    done
 
     REPO_NAME="deb ${BASE_URL}/${CODENAME}/  llvm-toolchain${LINKNAME}${LLVM_VERSION_STRING} main"
 
     # check if the repository exists for the distro and version
-    if ! wget -q --method=HEAD ${BASE_URL}/${CODENAME} >/dev/null 2>&1; then
+    if ! wget --no-hsts -q --method=HEAD "${BASE_URL}/${CODENAME}" >/dev/null 2>&1; then
         if [[ -n "${CODENAME_FROM_ARGUMENTS}" ]]; then
             echo "Specified codename '${CODENAME}' is not supported by this script."
         else
@@ -151,7 +160,7 @@ fi
 
 if [ ! -f /etc/apt/trusted.gpg.d/apt.llvm.org.asc ]; then
     # download GPG key once
-    wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
+    wget --no-hsts -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
 fi
 
 if [[ -z "`apt-key list 2> /dev/null | grep -i llvm`" ]]; then

--- a/features/src/llvm/llvm.sh
+++ b/features/src/llvm/llvm.sh
@@ -128,6 +128,11 @@ LLVM_VERSION_STRING=${LLVM_VERSION_PATTERNS[$LLVM_VERSION]}
 
 # join the repository name
 if [[ -n "${CODENAME}" ]]; then
+
+    if ! curl -fsSL "https://apt.llvm.org/${CODENAME}/dists/llvm-toolchain${LINKNAME}${LLVM_VERSION_STRING}/Release" >/dev/null 2>&1; then
+        LLVM_VERSION_STRING="";
+    fi
+
     REPO_NAME="deb ${BASE_URL}/${CODENAME}/  llvm-toolchain${LINKNAME}${LLVM_VERSION_STRING} main"
 
     # check if the repository exists for the distro and version

--- a/features/test/_global/scenarios.json
+++ b/features/test/_global/scenarios.json
@@ -22,12 +22,12 @@
         "installZsh": "true",
         "upgradePackages": "true"
       },
-      "ghcr.io/devcontainers/features/git:1": {
+      "ghcr.io/devcontainers/features/git:1.3.0": {
         "ppa": "true",
         "version": "latest"
       },
-      "ghcr.io/devcontainers/features/git-lfs:1": {},
-      "ghcr.io/devcontainers/features/github-cli:1": {},
+      "ghcr.io/devcontainers/features/git-lfs:1.2.1": {},
+      "ghcr.io/devcontainers/features/github-cli:1.0.12": {},
       "gitlab-cli": {
         "version": "latest"
       },

--- a/features/test/llvm/scenarios.json
+++ b/features/test/llvm/scenarios.json
@@ -39,13 +39,13 @@
         "version": "17"
       }
     }
-  },
-  "llvm_dev": {
-    "image": "ubuntu:22.04",
-    "features": {
-      "llvm": {
-        "version": "dev"
-      }
-    }
+  // },
+  // "llvm_dev": {
+  //   "image": "ubuntu:22.04",
+  //   "features": {
+  //     "llvm": {
+  //       "version": "dev"
+  //     }
+  //   }
   }
 }

--- a/features/test/utils/scenarios.json
+++ b/features/test/utils/scenarios.json
@@ -17,12 +17,12 @@
         "installZsh": "true",
         "upgradePackages": "true"
       },
-      "ghcr.io/devcontainers/features/git:1": {
+      "ghcr.io/devcontainers/features/git:1.3.0": {
         "ppa": "true",
         "version": "latest"
       },
-      "ghcr.io/devcontainers/features/git-lfs:1": {},
-      "ghcr.io/devcontainers/features/github-cli:1": {},
+      "ghcr.io/devcontainers/features/git-lfs:1.2.1": {},
+      "ghcr.io/devcontainers/features/github-cli:1.0.12": {},
       "gitlab-cli": {},
       "cmake": {},
       "ninja": {},
@@ -61,12 +61,12 @@
         "installZsh": "true",
         "upgradePackages": "true"
       },
-      "ghcr.io/devcontainers/features/git:1": {
+      "ghcr.io/devcontainers/features/git:1.3.0": {
         "ppa": "true",
         "version": "latest"
       },
-      "ghcr.io/devcontainers/features/git-lfs:1": {},
-      "ghcr.io/devcontainers/features/github-cli:1": {},
+      "ghcr.io/devcontainers/features/git-lfs:1.2.1": {},
+      "ghcr.io/devcontainers/features/github-cli:1.0.12": {},
       "gitlab-cli": {},
       "cmake": {},
       "ninja": {},
@@ -105,12 +105,12 @@
         "installZsh": "true",
         "upgradePackages": "true"
       },
-      "ghcr.io/devcontainers/features/git:1": {
+      "ghcr.io/devcontainers/features/git:1.3.0": {
         "ppa": "true",
         "version": "latest"
       },
-      "ghcr.io/devcontainers/features/git-lfs:1": {},
-      "ghcr.io/devcontainers/features/github-cli:1": {},
+      "ghcr.io/devcontainers/features/git-lfs:1.2.1": {},
+      "ghcr.io/devcontainers/features/github-cli:1.0.12": {},
       "gitlab-cli": {},
       "cmake": {},
       "ninja": {},

--- a/image/.devcontainer/devcontainer.json
+++ b/image/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
       "installZsh": "true",
       "upgradePackages": "true"
     },
-    "ghcr.io/devcontainers/features/git:1": {
+    "ghcr.io/devcontainers/features/git:1.3.0": {
       "ppa": "true",
       "version": "latest"
     },

--- a/image/.devcontainer/devcontainer.json
+++ b/image/.devcontainer/devcontainer.json
@@ -25,10 +25,10 @@
       "ppa": "true",
       "version": "latest"
     },
-    "ghcr.io/devcontainers/features/git-lfs:1": {
+    "ghcr.io/devcontainers/features/git-lfs:1.2.1": {
       "autoPull": false
     },
-    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/features/github-cli:1.0.12": {},
     "./features/src/gitlab-cli": {},
     "./features/src/cmake": {},
     "./features/src/ninja": {},

--- a/matrix.yml
+++ b/matrix.yml
@@ -25,8 +25,9 @@ x-llvm-13: &llvm_13 { name: "llvm", version: "13" }
 x-llvm-14: &llvm_14 { name: "llvm", version: "14" }
 x-llvm-15: &llvm_15 { name: "llvm", version: "15" }
 x-llvm-16: &llvm_16 { name: "llvm", version: "16" }
-x-llvm-prev: &llvm_17 { name: "llvm", version: "17" }
-x-llvm-curr: &llvm_18 { name: "llvm", version: "18" }
+x-llvm-17: &llvm_17 { name: "llvm", version: "17" }
+x-llvm-prev: &llvm_18 { name: "llvm", version: "18" }
+x-llvm-curr: &llvm_19 { name: "llvm", version: "19" }
 x-llvm-env: &llvm_env {CC: "clang", CXX: "clang++", CUDAHOSTCXX: "clang++"}
 
 x-nvhpc-prev: &nvhpc_prev { name: "nvhpc", version: "24.3" }
@@ -40,7 +41,7 @@ x-ucx-rapids: &ucx_rapids {name: "ucx", version: "1.17.0"}
 x-openmpi: &openmpi {name: "openmpi"}
 
 x-cccl-dev: &cccl_dev { name: "cccl-dev", hide: true }
-x-clangd-dev: &clangd_dev {name: "llvm", version: "dev", packages: "clangd", hide: true}
+x-clangd-dev: &clangd_dev {name: "llvm", version: "19", packages: "clangd", hide: true}
 x-clang-format-cccl: &clang_format_cccl {name: "llvm", version: "18", packages: "clang-format", hide: true}
 x-clang-format-rapids: &clang_format_rapids {name: "llvm", version: "16", packages: "clang-format", hide: true}
 
@@ -109,6 +110,8 @@ include:
   - {features: [*python, *llvm_17, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *clang_format_cccl, *clangd_dev, *cccl_dev], env: *llvm_env}
   - {features: [*python, *llvm_18, {<<: *cuda_curr_min, <<: *cccl_cuda_opts}, *clang_format_cccl, *clangd_dev, *cccl_dev], env: *llvm_env}
   - {features: [*python, *llvm_18, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *clang_format_cccl, *clangd_dev, *cccl_dev], env: *llvm_env}
+  - {features: [*python, *llvm_19, {<<: *cuda_curr_min, <<: *cccl_cuda_opts}, *clang_format_cccl, *clangd_dev, *cccl_dev], env: *llvm_env}
+  - {features: [*python, *llvm_19, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *clang_format_cccl, *clangd_dev, *cccl_dev], env: *llvm_env}
   - {features: [*python, *oneapi_2022, {<<: *cuda_curr_max, <<: *cccl_cuda_opts}, *clang_format_cccl, *clangd_dev, *cccl_dev], env: *onapi_env}
 
 # Hack for getting gcc-13.2

--- a/matrix.yml
+++ b/matrix.yml
@@ -35,7 +35,7 @@ x-nvhpc-curr: &nvhpc_curr { name: "nvhpc", version: "24.5" }
 x-nvhpc-env: &nvhpc_env {CC: "nvc", CXX: "nvc++"}
 
 x-mambaforge: &conda { name: "mambaforge" }
-x-python: &python { name: "ghcr.io/devcontainers/features/python:1", version: "os-provided", installTools: "false", hide: true }
+x-python: &python { name: "ghcr.io/devcontainers/features/python:1.6.2", version: "os-provided", installTools: "false", hide: true }
 x-ucx-rapids: &ucx_rapids {name: "ucx", version: "1.17.0"}
 x-openmpi: &openmpi {name: "openmpi"}
 


### PR DESCRIPTION
Seems like https://github.com/devcontainers/features/commit/f45518999e598127c46ece79a607a241eb5e38d6 changed the curl calls in a way that's incompatible with Ubuntu18.04.

Related issue: https://github.com/devcontainers/features/issues/1055