### PR TITLE
Specify use_cuda_wheels=false in matrix entry

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.10.5",
+  "version": "24.10.6",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-pip-dependencies.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-pip-dependencies.sh
@@ -79,6 +79,7 @@ make_pip_dependencies() {
         cuda="${cuda_version}"
         cuda_suffixed=true
         py="${python_version}"
+        use_cuda_wheels=false
     );
 
     # add extra arguments (if there are conflicts, e.g. 'py=3.10;py=3.11', it's fine... the last one will win)


### PR DESCRIPTION
With packages depending on CUDA wheels by default, we want to disable that behavior in devcontainers. Add a `use_cuda_wheels=false` matrix entry.

Contributes to https://github.com/rapidsai/build-planning/issues/35