### PR TITLE
add manifest entry for libcuspatial wheels

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.10.7",
+  "version": "24.10.8",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -256,6 +256,9 @@ repos:
       sub_dir: cpp
       depends: [cudf]
   python:
+    - name: libcuspatial
+      sub_dir: python/libcuspatial
+      depends: [cuspatial]
     - name: cuproj
       sub_dir: python/cuproj
       depends: [rmm]

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -273,4 +273,4 @@ repos:
     - name: cuspatial
       sub_dir: python/cuspatial
       depends: [cuspatial]
-      args: {cmake: -DFIND_CUSPATIAL_CPP=ON, install: *rapids_build_backend_args}
+      args: {install: *rapids_build_backend_args}


### PR DESCRIPTION
I'm working on adding `libcuspatial` wheels in https://github.com/rapidsai/cuspatial/pull/1450.

This proposes adding a manifest entry for `rapids-build-utils`, to build them in devcontainers.

## Notes for Reviewers

### How I tested this

Similar to https://github.com/rapidsai/devcontainers/pull/271#issuecomment-2307290687.

Rebuilt the CUDA 12.5 pip devcontainer, with only `cudf` and `cuspatial` repos mounted in, and with `cuspatial` pointed at the branch from https://github.com/rapidsai/cuspatial/pull/1450.

```shell
# build libcudf.so + all the cudf Python wheels
build-cudf -j

# build libcuspatial.so + all the cuspatial Python wheels
build-cuspatial -j

# test that 'libcuspatial' is importable
python -c "import libcuspatial; l = libcuspatial.load_library(); print(l)"
# None

# test that 'cuspatial' and 'cuproj' are importable
python -c "import cuspatial;import cuproj"

# test that cudf actually works
pushd ./cuspatial/python/cuspatial/cuspatial
python -m pytest \
  --cache-clear \
  --numprocesses=8 \
  --dist=worksteal \
  tests/
```

All worked 😁 

### Merge order?

Once https://github.com/rapidsai/cuspatial/pull/1450 is close to being merged, let's merge this PR and then restart the `devcontainers` CI job there.