### PR TITLE
Pin to Python 3.11.

### DIFF
--- a/matrix.yml
+++ b/matrix.yml
@@ -157,7 +157,7 @@ include:
   - { features: [*python, *clang_format_rapids, *clangd_dev, *cuda_curr_max_rapids, *ucx_rapids, *openmpi], env: *gcc_env }
 
   # mambaforge
-  - features: [*conda]
+  - { features: [*conda], env: { "PYTHON_VERSION": "3.11" } }
 
   ###
   # Legacy CUDA 11.x + mambaforge image. Needed so the cudatoolkit 11.x
@@ -166,4 +166,4 @@ include:
   ###
 
   # cuda-mambaforge
-  - features: [*cuda_prev_max, *conda]
+  - { features: [*cuda_prev_max, *conda], env: { "PYTHON_VERSION": "3.11" } }


### PR DESCRIPTION
Pin devcontainers to Python 3.11.

During the migration to Python 3.12, we are getting `py=3.12` as a matrix selector for rapids-dependency-file-generator, which in turn selects `python=3.12` for repositories that have added support. However, for repositories that have not migrated yet, we get the fallback matrix `python>=3.10,<3.12` which conflicts with the other pinning. To avoid this, we can pin devcontainers to use `PYTHON_VERSION="3.11"` which will be passed through to the logic here: https://github.com/rapidsai/devcontainers/blob/f9155e8267cb531efcd041eb35217b82f4083aeb/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-dependencies.sh#L62-L73
