### PR TITLE
pin mambaforge images to Python 3.12

### DIFF
--- a/matrix.yml
+++ b/matrix.yml
@@ -157,7 +157,7 @@ include:
   - { features: [*python, *clang_format_rapids, *clangd_dev, *cuda_curr_max_rapids, *ucx_rapids, *openmpi], env: *gcc_env }
 
   # mambaforge
-  - { features: [*conda], env: { "PYTHON_VERSION": "3.11" } }
+  - { features: [*conda], env: { "PYTHON_VERSION": "3.12" } }
 
   ###
   # Legacy CUDA 11.x + mambaforge image. Needed so the cudatoolkit 11.x
@@ -166,4 +166,4 @@ include:
   ###
 
   # cuda-mambaforge
-  - { features: [*cuda_prev_max, *conda], env: { "PYTHON_VERSION": "3.11" } }
+  - { features: [*cuda_prev_max, *conda], env: { "PYTHON_VERSION": "3.12" } }


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/40

#388 pinned to Python 3.11 for building the mambaforge images here, to prevent issues in the situation where some but not all RAPIDS repos had added Python 3.12 support.

This proposes moving that pin to Python 3.12.

Keeping this hard-coded will prevent similar issues the next time we go to add a Python version (Python 3.13) across RAPIDS.