### PR TITLE
Various fixes to args

### DIFF
--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -58,11 +58,11 @@ repos:
     - name: libkvikio
       sub_dir: python/libkvikio
       depends: [KvikIO]
-      args: {cmake: -DFIND_KVIKIO_CPP=ON, install: *rapids_build_backend_args}
+      args: {install: *rapids_build_backend_args}
     - name: kvikio
       sub_dir: python/kvikio
       depends: [KvikIO]
-      args: {cmake: -DFIND_KVIKIO_CPP=ON, install: *rapids_build_backend_args}
+      args: {install: *rapids_build_backend_args}
 
 - name: cudf
   path: cudf
@@ -71,9 +71,6 @@ repos:
     - name: cudf
       sub_dir: cpp
       depends: [KvikIO]
-      args:
-        cmake: |
-          $([ "pip" = ${PYTHON_PACKAGE_MANAGER} ] && echo -DUSE_LIBARROW_FROM_PYARROW=ON || echo)
     - name: cudf_kafka
       sub_dir: cpp/libcudf_kafka
       depends: [cudf]
@@ -81,14 +78,15 @@ repos:
     - name: libcudf
       sub_dir: python/libcudf
       depends: [cudf]
+      args: {install: *rapids_build_backend_args}
     - name: pylibcudf
       sub_dir: python/pylibcudf
       depends: [cudf]
-      args: {cmake: -DFIND_CUDF_CPP=ON, install: *rapids_build_backend_args}
+      args: {install: *rapids_build_backend_args}
     - name: cudf
       sub_dir: python/cudf
       depends: [cudf]
-      args: {cmake: -DFIND_CUDF_CPP=ON, install: *rapids_build_backend_args}
+      args: {install: *rapids_build_backend_args}
     - name: dask_cudf
       sub_dir: python/dask_cudf
       args: {install: *rapids_build_backend_args}
@@ -217,9 +215,7 @@ repos:
     - name: cugraph_etl
       sub_dir: cpp/libcugraph_etl
       depends: [cudf, cugraph]
-      args:
-        cmake: $([ "pip" = ${PYTHON_PACKAGE_MANAGER} ] && echo -DUSE_LIBARROW_FROM_PYARROW=ON || echo)
-        install: *rapids_build_backend_args
+      args: {install: *rapids_build_backend_args}
   python:
     - name: pylibcugraph
       sub_dir: python/pylibcugraph
@@ -259,6 +255,7 @@ repos:
     - name: libcuspatial
       sub_dir: python/libcuspatial
       depends: [cuspatial]
+      args: {install: *rapids_build_backend_args}
     - name: cuproj
       sub_dir: python/cuproj
       depends: [rmm]


### PR DESCRIPTION
There have been a number of changes to RAPIDS builds over the course of this release and not all changes were fully propagated to the devcontainers repo. This repo addresses the following:
- As of https://github.com/rapidsai/kvikio/pull/369, kvikio produces wheels, and https://github.com/rapidsai/kvikio/pull/439 contains critical fixes that allow the kvikio Python wheel to use the C++ libkvikio wheel. In RAPIDS Python builds we have consistently removed support for the Python build triggering the C++ build as we have created C++ wheels since in both conda and pip environments we now expect the library to be found and we do not need to automatically support the more esoteric use case of someone turning off build isolation but not having the C++ library available (devs can handle this case themselves if they wish). As a result, once https://github.com/rapidsai/kvikio/pull/466 is merged, the `FIND_KVIKIO_CPP` variable will be completely superfluous and we can remove that here.
- As of https://github.com/rapidsai/cudf/pull/16640 libcudf no longer links to libarrow and `USE_LIBARROW_FROM_PYARROW` is no longer used.
- The libcudf and libcuspatial Python package builds in the devcontainer should (like all other Python packages) omit the CUDA version suffix. For that, they need to use the `rapids_build_backend_args`.