### PR TITLE
Make profilers available by default in devcontainers

### DIFF
--- a/.devcontainer/cuda12.0-conda/devcontainer.json
+++ b/.devcontainer/cuda12.0-conda/devcontainer.json
@@ -15,10 +15,33 @@
   ],
   "hostRequirements": {"gpu": "optional"},
   "features": {
+    "./features/src/cuda": {
+      "version": "12.0",
+      "installCompilers": false,
+      "installProfilers": true,
+      "installCTKLibraries": false,
+      "installDevPackages": false,
+      "installcuDNN": false,
+      "installcuTensor": false,
+      "installNCCL": false,
+      "installCUDARuntime": false,
+      "installNVRTC": false,
+      "installOpenCL": false,
+      "installcuBLAS": false,
+      "installcuSPARSE": false,
+      "installcuFFT": false,
+      "installcuFile": false,
+      "installcuRAND": false,
+      "installcuSOLVER": false,
+      "installNPP": false,
+      "installnvJPEG": false,
+      "pruneStaticLibs": true
+    },
     "./features/src/utils": {},
     "./features/src/rapids-build-utils": {}
   },
   "overrideFeatureInstallOrder": [
+    "./features/src/cuda",
     "./features/src/utils",
     "./features/src/rapids-build-utils"
   ],

--- a/.devcontainer/cuda12.0-pip/devcontainer.json
+++ b/.devcontainer/cuda12.0-pip/devcontainer.json
@@ -22,7 +22,8 @@
       "installcuDNN": true,
       "installcuSOLVER": true,
       "installcuRAND": true,
-      "installcuSPARSE": true
+      "installcuSPARSE": true,
+      "installProfilers": true
     },
     "./features/src/utils": {},
     "./features/src/rapids-build-utils": {}

--- a/.devcontainer/cuda12.2-conda/devcontainer.json
+++ b/.devcontainer/cuda12.2-conda/devcontainer.json
@@ -15,10 +15,33 @@
   ],
   "hostRequirements": {"gpu": "optional"},
   "features": {
+    "./features/src/cuda": {
+      "version": "12.2",
+      "installCompilers": false,
+      "installProfilers": true,
+      "installCTKLibraries": false,
+      "installDevPackages": false,
+      "installcuDNN": false,
+      "installcuTensor": false,
+      "installNCCL": false,
+      "installCUDARuntime": false,
+      "installNVRTC": false,
+      "installOpenCL": false,
+      "installcuBLAS": false,
+      "installcuSPARSE": false,
+      "installcuFFT": false,
+      "installcuFile": false,
+      "installcuRAND": false,
+      "installcuSOLVER": false,
+      "installNPP": false,
+      "installnvJPEG": false,
+      "pruneStaticLibs": true
+    },
     "./features/src/utils": {},
     "./features/src/rapids-build-utils": {}
   },
   "overrideFeatureInstallOrder": [
+    "./features/src/cuda",
     "./features/src/utils",
     "./features/src/rapids-build-utils"
   ],

--- a/.devcontainer/cuda12.2-pip/devcontainer.json
+++ b/.devcontainer/cuda12.2-pip/devcontainer.json
@@ -22,7 +22,8 @@
       "installcuDNN": true,
       "installcuSOLVER": true,
       "installcuRAND": true,
-      "installcuSPARSE": true
+      "installcuSPARSE": true,
+      "installProfilers": true
     },
     "./features/src/utils": {},
     "./features/src/rapids-build-utils": {}

--- a/.devcontainer/cuda12.5-conda/devcontainer.json
+++ b/.devcontainer/cuda12.5-conda/devcontainer.json
@@ -15,10 +15,33 @@
   ],
   "hostRequirements": {"gpu": "optional"},
   "features": {
+    "./features/src/cuda": {
+      "version": "12.5",
+      "installCompilers": false,
+      "installProfilers": true,
+      "installCTKLibraries": false,
+      "installDevPackages": false,
+      "installcuDNN": false,
+      "installcuTensor": false,
+      "installNCCL": false,
+      "installCUDARuntime": false,
+      "installNVRTC": false,
+      "installOpenCL": false,
+      "installcuBLAS": false,
+      "installcuSPARSE": false,
+      "installcuFFT": false,
+      "installcuFile": false,
+      "installcuRAND": false,
+      "installcuSOLVER": false,
+      "installNPP": false,
+      "installnvJPEG": false,
+      "pruneStaticLibs": true
+    },
     "./features/src/utils": {},
     "./features/src/rapids-build-utils": {}
   },
   "overrideFeatureInstallOrder": [
+    "./features/src/cuda",
     "./features/src/utils",
     "./features/src/rapids-build-utils"
   ],

--- a/.devcontainer/cuda12.5-pip/devcontainer.json
+++ b/.devcontainer/cuda12.5-pip/devcontainer.json
@@ -22,7 +22,8 @@
       "installcuDNN": true,
       "installcuSOLVER": true,
       "installcuRAND": true,
-      "installcuSPARSE": true
+      "installcuSPARSE": true,
+      "installProfilers": true
     },
     "./features/src/utils": {},
     "./features/src/rapids-build-utils": {}


### PR DESCRIPTION
I added them explicitly to the pip containers in case the default for the cuda feature changes in the future.