### PR TITLE
Fix kvikio casing and remove unnecessary rmm dependency

### DIFF
--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -53,7 +53,7 @@ repos:
   cpp:
     - name: kvikio
       sub_dir: cpp
-      depends: [rmm]
+      depends: []
   python:
     - name: libkvikio
       sub_dir: python/libkvikio

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -53,7 +53,6 @@ repos:
   cpp:
     - name: kvikio
       sub_dir: cpp
-      depends: []
   python:
     - name: libkvikio
       sub_dir: python/libkvikio

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -51,17 +51,17 @@ repos:
   path: kvikio
   git: {<<: *git_defaults, repo: kvikio}
   cpp:
-    - name: KvikIO
+    - name: kvikio
       sub_dir: cpp
       depends: [rmm]
   python:
     - name: libkvikio
       sub_dir: python/libkvikio
-      depends: [KvikIO]
+      depends: [kvikio]
       args: {install: *rapids_build_backend_args}
     - name: kvikio
       sub_dir: python/kvikio
-      depends: [KvikIO]
+      depends: [kvikio]
       args: {install: *rapids_build_backend_args}
 
 - name: cudf
@@ -70,7 +70,7 @@ repos:
   cpp:
     - name: cudf
       sub_dir: cpp
-      depends: [KvikIO]
+      depends: [kvikio]
     - name: cudf_kafka
       sub_dir: cpp/libcudf_kafka
       depends: [cudf]


### PR DESCRIPTION
The case-sensitive name `KvikIO` is throwing off `find_package` searches in various places.