### PR TITLE
move cugraph projects around for 24.12

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.12.3",
+  "version": "24.12.4",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.12.2",
+  "version": "24.12.3",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -224,7 +224,7 @@ repos:
 
 - name: cugraph-gnn
   path: cugraph-gnn
-  git: {<<: *git_defaults, repo: cugraph-gnn, branch: devcontainers}
+  git: {host: github, upstream: jameslamb, repo: cugraph-gnn, tag: devcontainers}
   cpp:
     - name: wholegraph
       sub_dir: cpp

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -224,9 +224,6 @@ repos:
       sub_dir: python/cugraph
       depends: [cugraph]
       args: {cmake: -DFIND_CUGRAPH_CPP=ON, install: *rapids_build_backend_args}
-    - name: nx-cugraph
-      sub_dir: python/nx-cugraph
-      args: {install: *rapids_build_backend_args}
     - name: cugraph-dgl
       sub_dir: python/cugraph-dgl
       args: {install: *rapids_build_backend_args}
@@ -241,6 +238,14 @@ repos:
       args: {install: *rapids_build_backend_args}
     - name: cugraph-service-server
       sub_dir: python/cugraph-service/server
+      args: {install: *rapids_build_backend_args}
+
+- name: nx-cugraph
+  path: nx-cugraph
+  git: {<<: *git_defaults, repo: nx-cugraph}
+  python:
+    - name: nx-cugraph
+      sub_dir: .
       args: {install: *rapids_build_backend_args}
 
 - name: cuspatial

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -102,7 +102,7 @@ repos:
 
 - name: raft
   path: raft
-  git: {<<: *git_defaults, repo: raft}
+  git: {host: github, upstream: jameslamb, repo: raft, tag: wheel-validation}
   cpp:
     - name: raft
       sub_dir: cpp

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -102,7 +102,7 @@ repos:
 
 - name: raft
   path: raft
-  git: {host: github, upstream: jameslamb, repo: raft, tag: wheel-validation}
+  git: {<<: *git_defaults, repo: raft}
   cpp:
     - name: raft
       sub_dir: cpp

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -187,21 +187,6 @@ repos:
         cmake: -DCMAKE_CUDA_ARCHITECTURES="${CUDAARCHS}"
         install: *rapids_build_backend_args
 
-- name: wholegraph
-  path: wholegraph
-  git: {<<: *git_defaults, repo: wholegraph}
-  cpp:
-    - name: wholegraph
-      sub_dir: cpp
-      depends: [raft]
-      args:
-        cmake: -DCMAKE_CUDA_ARCHITECTURES="${CUDAARCHS}"
-  python:
-    - name: wholegraph
-      sub_dir: python/pylibwholegraph
-      depends: [wholegraph]
-      args: {install: *rapids_build_backend_args}
-
 - name: cugraph
   path: cugraph
   git: {<<: *git_defaults, repo: cugraph}
@@ -224,9 +209,6 @@ repos:
       sub_dir: python/cugraph
       depends: [cugraph]
       args: {cmake: -DFIND_CUGRAPH_CPP=ON, install: *rapids_build_backend_args}
-    - name: cugraph-dgl
-      sub_dir: python/cugraph-dgl
-      args: {install: *rapids_build_backend_args}
     - name: cugraph-equivariant
       sub_dir: python/cugraph-equivariant
       args: {install: *rapids_build_backend_args}
@@ -238,6 +220,27 @@ repos:
       args: {install: *rapids_build_backend_args}
     - name: cugraph-service-server
       sub_dir: python/cugraph-service/server
+      args: {install: *rapids_build_backend_args}
+
+- name: cugraph-gnn
+  path: cugraph-gnn
+  git: {<<: *git_defaults, repo: cugraph-gnn}
+  cpp:
+    - name: wholegraph
+      sub_dir: cpp
+      depends: [raft]
+      args:
+        cmake: -DCMAKE_CUDA_ARCHITECTURES="${CUDAARCHS}"
+  python:
+    - name: wholegraph
+      sub_dir: python/pylibwholegraph
+      depends: [wholegraph]
+      args: {install: *rapids_build_backend_args}
+    - name: cugraph-dgl
+      sub_dir: python/cugraph-dgl
+      args: {install: *rapids_build_backend_args}
+    - name: cugraph_pyg
+      sub_dir: python/cugraph-pyg
       args: {install: *rapids_build_backend_args}
 
 - name: nx-cugraph

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -209,12 +209,6 @@ repos:
       sub_dir: python/cugraph
       depends: [cugraph]
       args: {cmake: -DFIND_CUGRAPH_CPP=ON, install: *rapids_build_backend_args}
-    - name: cugraph-equivariant
-      sub_dir: python/cugraph-equivariant
-      args: {install: *rapids_build_backend_args}
-    - name: cugraph_pyg
-      sub_dir: python/cugraph-pyg
-      args: {install: *rapids_build_backend_args}
     - name: cugraph-service-client
       sub_dir: python/cugraph-service/client
       args: {install: *rapids_build_backend_args}

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -224,7 +224,7 @@ repos:
 
 - name: cugraph-gnn
   path: cugraph-gnn
-  git: {<<: *git_defaults, repo: cugraph-gnn}
+  git: {<<: *git_defaults, repo: cugraph-gnn, branch: devcontainers}
   cpp:
     - name: wholegraph
       sub_dir: cpp

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -218,7 +218,7 @@ repos:
 
 - name: cugraph-gnn
   path: cugraph-gnn
-  git: {host: github, upstream: jameslamb, repo: cugraph-gnn, tag: devcontainers}
+  git: {<<: *git_defaults, repo: cugraph-gnn}
   cpp:
     - name: wholegraph
       sub_dir: cpp


### PR DESCRIPTION
Development of some `cugraph` projects is moving in 24.12.

```text
# GNN packages
cugraph-dgl: rapidsai/cugraph -> rapidsai/cugraph-gnn
cugraph-pyg: rapidsai/cugraph -> rapidsai/cugraph-gnn
wholegraph: rapidsai/wholegraph -> rapidsai/cugraph-gnn

# networkx
nx-cugraph: rapidsai/cugraph -> rapidsai/nx-cugraph

# other
cugraph-equivariant -> (removed)
```

This updates the `rapids-build-utils` manifest to reflect those changes.

## Notes for Reviewers

The `nx-cugraph` changes ended up getting split off into their own PR: #418