### PR TITLE
Remove nx-cugraph from cugraph

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.12.2",
+  "version": "24.12.3",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -240,6 +240,14 @@ repos:
       sub_dir: python/cugraph-service/server
       args: {install: *rapids_build_backend_args}
 
+- name: nx-cugraph
+  path: nx-cugraph
+  git: {<<: *git_defaults, repo: nx-cugraph}
+  python:
+    - name: nx-cugraph
+      sub_dir: .
+      args: {install: *rapids_build_backend_args}
+
 - name: cuspatial
   path: cuspatial
   git: {<<: *git_defaults, repo: cuspatial}

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -224,9 +224,6 @@ repos:
       sub_dir: python/cugraph
       depends: [cugraph]
       args: {cmake: -DFIND_CUGRAPH_CPP=ON, install: *rapids_build_backend_args}
-    - name: nx-cugraph
-      sub_dir: python/nx-cugraph
-      args: {install: *rapids_build_backend_args}
     - name: cugraph-dgl
       sub_dir: python/cugraph-dgl
       args: {install: *rapids_build_backend_args}


### PR DESCRIPTION
I believe this is needed to remove `nx-cugraph` from the `cugraph` repo being done in https://github.com/rapidsai/cugraph/pull/4756

This is a subset of the changes @jameslamb is making in https://github.com/rapidsai/devcontainers/pull/417. Does it make sense to do this change for `nx-cugraph` and `cugraph-gnn` independently (how close is `cugraph-gnn` to being removed?)? Should we also add `nx-cugraph` as done in that PR? Anything else?

@nv-rliu @jameslamb @rlratzel 