### PR TITLE
prefer system installs of UCX libraries when using RAPIDS wheels

### DIFF
--- a/.devcontainer/rapids.Dockerfile
+++ b/.devcontainer/rapids.Dockerfile
@@ -28,6 +28,8 @@ RUN apt update -y \
 
 ENV DEFAULT_VIRTUAL_ENV=rapids
 
+ENV RAPIDS_LIBUCX_PREFER_SYSTEM_LIBRARY=true
+
 FROM ${BASE} as conda-base
 
 ENV DEFAULT_CONDA_ENV=rapids

--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -4,8 +4,7 @@
   "version": "24.12.4",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
-    "BASH_ENV": "/etc/bash.bash_env",
-    "RAPIDS_LIBUCX_PREFER_SYSTEM_LIBRARY": "true"
+    "BASH_ENV": "/etc/bash.bash_env"
   },
   "postStartCommand": [
     "/bin/bash",

--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,10 +1,11 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "24.12.3",
+  "version": "24.12.4",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
-    "BASH_ENV": "/etc/bash.bash_env"
+    "BASH_ENV": "/etc/bash.bash_env",
+    "RAPIDS_LIBUCX_PREFER_SYSTEM_LIBRARY": "true"
   },
   "postStartCommand": [
     "/bin/bash",


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/118

Should only be merged if / after we merge https://github.com/rapidsai/ucx-wheels/pull/13. That PR switches `libucx` wheels' loading behavior, such that `libucx.load_library()` (which `ucx-py` and `libucxx` call at import time) prefers the `libuc{m,p,s}.so` provided by the `libucx` wheels.

https://github.com/rapidsai/ucx-wheels/pull/13 introduces an environment variable to control that... this proposes setting that, to continue preferring system-installed UCX libraries in devcontainers.