### PR TITLE
Remove ANN benchmark options from RAFT.

### DIFF
--- a/.devcontainer/build-rapids.sh
+++ b/.devcontainer/build-rapids.sh
@@ -54,7 +54,7 @@ build_rapids() {
     (
         echo "building RAFT";
         clean-raft;
-        build-raft -DBUILD_PRIMS_BENCH=ON -DBUILD_ANN_BENCH=ON --verbose;
+        build-raft -DBUILD_PRIMS_BENCH=ON --verbose;
         sccache -s;
     ) 2>&1 | maybe_write_build_log raft;
 

--- a/.github/workflows/build-all-rapids-repos.yml
+++ b/.github/workflows/build-all-rapids-repos.yml
@@ -50,7 +50,6 @@ jobs:
           -DBUILD_SHARED_LIBS=ON         \
           -DBUILD_TESTS=ON               \
           -DBUILD_BENCHMARKS=ON          \
-          -DBUILD_ANN_BENCH=ON           \
           -DBUILD_PRIMS_BENCH=ON         \
           -DRAFT_COMPILE_LIBRARY=ON      \
           -DBUILD_CUGRAPH_MG_TESTS=ON    \


### PR DESCRIPTION
`-DBUILD_ANN_BENCH` is no longer used, as RAFT has removed ANN benchmarks.
