### PR TITLE
Upgrade CCCL clang-format to 19

### DIFF
--- a/matrix.yml
+++ b/matrix.yml
@@ -43,7 +43,7 @@ x-openmpi: &openmpi { name: "openmpi" }
 x-cccl-dev: &cccl_dev { name: "cccl-dev", hide: true }
 x-clangd-dev: &clangd_dev { name: "llvm", version: "dev", packages: "clangd", hide: true }
 x-clangd-dev-bionic: &clangd_dev_bionic { name: "llvm", version: "19", packages: "clangd", hide: true }
-x-clang-format-cccl: &clang_format_cccl { name: "llvm", version: "18", packages: "clang-format llvm-tools", hide: true }
+x-clang-format-cccl: &clang_format_cccl { name: "llvm", version: "19", packages: "clang-format llvm-tools", hide: true }
 x-clang-format-rapids: &clang_format_rapids { name: "llvm", version: "16", packages: "clang-format", hide: true }
 
 # CCCL only needs a subset of the full CTK:


### PR DESCRIPTION
Our pre-commit is [upgrading to clang-format 19](https://github.com/NVIDIA/cccl/pull/3248), so we need this version in the devcontainers as well.