### PR TITLE
add libcugraph Python builds

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "25.2.4",
+  "version": "25.2.5",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "25.2.5",
+  "version": "25.2.6",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -147,8 +147,7 @@ repos:
 
 - name: cuml
   path: cuml
-  # TODO(jameslamb): revert this before merging
-  git: {<<: *git_defaults, repo: cuml, upstream: jameslamb, tag: libcuml-wheels}
+  git: {<<: *git_defaults, repo: cuml}
   cpp:
     - name: cuml
       sub_dir: cpp
@@ -156,14 +155,10 @@ repos:
       parallelism:
         max_device_obj_memory_usage: 3Gi
   python:
-    - name: libcuml
-      sub_dir: python/libcuml
-      depends: [cuml]
-      args: {install: *rapids_build_backend_args}
     - name: cuml
       sub_dir: python/cuml
       depends: [cuml]
-      args: {install: *rapids_build_backend_args}
+      args: {cmake: -DFIND_CUML_CPP=ON, install: *rapids_build_backend_args}
 
 - name: cugraph-ops
   path: cugraph-ops

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -99,8 +99,7 @@ repos:
 
 - name: raft
   path: raft
-  # TODO(jameslamb): revert this before merging
-  git: {<<: *git_defaults, repo: raft, upstream: jameslamb, tag: libraft-wheels}
+  git: {<<: *git_defaults, repo: raft}
   cpp:
     - name: raft
       sub_dir: cpp
@@ -212,7 +211,7 @@ repos:
     - name: libcugraph
       sub_dir: python/libcugraph
       depends: [cugraph]
-      args: {install: *rapids_build_backend_args}  
+      args: {install: *rapids_build_backend_args}
     - name: pylibcugraph
       sub_dir: python/pylibcugraph
       depends: [cugraph]

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -190,8 +190,7 @@ repos:
 
 - name: cugraph
   path: cugraph
-  # TODO(jameslamb): revert this before merging
-  git: {<<: *git_defaults, repo: cugraph, upstream: jameslamb, tag: libcugraph-wheel}
+  git: {<<: *git_defaults, repo: cugraph}
   cpp:
     - name: cugraph
       sub_dir: cpp

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -99,7 +99,8 @@ repos:
 
 - name: raft
   path: raft
-  git: {<<: *git_defaults, repo: raft}
+  # TODO(jameslamb): revert this before merging
+  git: {<<: *git_defaults, repo: raft, upstream: jameslamb, tag: libraft-wheels}
   cpp:
     - name: raft
       sub_dir: cpp
@@ -108,14 +109,18 @@ repos:
         max_device_obj_memory_usage: 3Gi
       args: {cmake: -DRAFT_COMPILE_LIBRARY=ON}
   python:
+    - name: libraft
+      sub_dir: python/libraft
+      depends: [raft]
+      args: {install: *rapids_build_backend_args}
     - name: pylibraft
       sub_dir: python/pylibraft
       depends: [raft]
-      args: {cmake: -DFIND_RAFT_CPP=ON, install: *rapids_build_backend_args}
+      args: {install: *rapids_build_backend_args}
     - name: raft-dask
       sub_dir: python/raft-dask
       depends: [ucxx, raft]
-      args: {cmake: -DFIND_RAFT_CPP=ON, install: *rapids_build_backend_args}
+      args: {install: *rapids_build_backend_args}
 
 - name: cuvs
   path: cuvs
@@ -143,7 +148,8 @@ repos:
 
 - name: cuml
   path: cuml
-  git: {<<: *git_defaults, repo: cuml}
+  # TODO(jameslamb): revert this before merging
+  git: {<<: *git_defaults, repo: cuml, upstream: jameslamb, tag: libcuml-wheels}
   cpp:
     - name: cuml
       sub_dir: cpp
@@ -151,10 +157,14 @@ repos:
       parallelism:
         max_device_obj_memory_usage: 3Gi
   python:
+    - name: libcuml
+      sub_dir: python/libcuml
+      depends: [cuml]
+      args: {install: *rapids_build_backend_args}
     - name: cuml
       sub_dir: python/cuml
       depends: [cuml]
-      args: {cmake: -DFIND_CUML_CPP=ON, install: *rapids_build_backend_args}
+      args: {install: *rapids_build_backend_args}
 
 - name: cugraph-ops
   path: cugraph-ops
@@ -186,7 +196,8 @@ repos:
 
 - name: cugraph
   path: cugraph
-  git: {<<: *git_defaults, repo: cugraph}
+  # TODO(jameslamb): revert this before merging
+  git: {<<: *git_defaults, repo: cugraph, upstream: jameslamb, tag: libcugraph-wheel}
   cpp:
     - name: cugraph
       sub_dir: cpp
@@ -198,14 +209,18 @@ repos:
       depends: [cudf, cugraph]
       args: {install: *rapids_build_backend_args}
   python:
+    - name: libcugraph
+      sub_dir: python/libcugraph
+      depends: [cugraph]
+      args: {install: *rapids_build_backend_args}  
     - name: pylibcugraph
       sub_dir: python/pylibcugraph
       depends: [cugraph]
-      args: {cmake: -DFIND_CUGRAPH_CPP=ON, install: *rapids_build_backend_args}
+      args: {install: *rapids_build_backend_args}
     - name: cugraph
       sub_dir: python/cugraph
       depends: [cugraph]
-      args: {cmake: -DFIND_CUGRAPH_CPP=ON, install: *rapids_build_backend_args}
+      args: {install: *rapids_build_backend_args}
     - name: cugraph-service-client
       sub_dir: python/cugraph-service/client
       args: {install: *rapids_build_backend_args}


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/33

Adjusts `rapids-build-utils` manifest for release 25.02 to account for the introduction of new `libcugraph` wheels (https://github.com/rapidsai/cugraph/pull/4804).

## Notes for Reviewers

This shouldn't be merged still pointing at my forks. Plan:

1. admin-merge https://github.com/rapidsai/cugraph/pull/4804 once everything except devcontainers CI there is passing
2. point this PR at upstream `rapidsai/cugraph`
3. observe CI passing and merge this normally (or admin-merge to save time)