### PR TITLE
Disable CUDA 12.0 RAPIDS builds.

### DIFF
--- a/.github/workflows/build-all-rapids-repos.yml
+++ b/.github/workflows/build-all-rapids-repos.yml
@@ -36,7 +36,10 @@ jobs:
       pull-requests: read
     with:
       arch: '["amd64"]'
-      cuda: '["12.0", "12.5"]'
+      # Disabling CUDA 12.0 due to failures in cudf builds. See:
+      # https://github.com/rapidsai/devcontainers/pull/438#issuecomment-2596318879
+      #cuda: '["12.0", "12.5"]'
+      cuda: '["12.5"]'
       node_type: cpu32
       extra-repo-deploy-key: CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY
       extra-repo-deploy-key-2: CUGRAPH_OPS_SSH_PRIVATE_DEPLOY_KEY


### PR DESCRIPTION
CUDA 12.0 RAPIDS builds appear to be blocked due to a failure caused by https://github.com/rapidsai/cudf/pull/17289.

CUDA 12.5 builds are seemingly unaffected. For now, I am opening this PR to unblock devcontainers CI.
