### PR TITLE
add libcuvs Python builds

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "25.2.6",
+  "version": "25.2.7",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -123,8 +123,7 @@ repos:
 
 - name: cuvs
   path: cuvs
-  # TODO(jameslamb): revert this before merging
-  git: {<<: *git_defaults, repo: cuvs, upstream: jameslamb, tag: libcuvs-wheels}
+  git: {<<: *git_defaults, repo: cuvs}
   cpp:
     - name: cuvs
       sub_dir: cpp

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -123,7 +123,8 @@ repos:
 
 - name: cuvs
   path: cuvs
-  git: {<<: *git_defaults, repo: cuvs}
+  # TODO(jameslamb): revert this before merging
+  git: {<<: *git_defaults, repo: cuvs, upstream: jameslamb, tag: libcuvs-wheels}
   cpp:
     - name: cuvs
       sub_dir: cpp
@@ -132,10 +133,14 @@ repos:
         max_device_obj_memory_usage: 3Gi
       args: {cmake: -DBUILD_C_LIBRARY=ON}
   python:
+   - name: libcuvs
+      sub_dir: python/libcuvs
+      depends: [cuvs]
+      args: {install: *rapids_build_backend_args}
     - name: cuvs
       sub_dir: python/cuvs
       depends: [cuvs]
-      args: {cmake: -DFIND_CUVS_CPP=ON, install: *rapids_build_backend_args}
+      args: {install: *rapids_build_backend_args}
 
 - name: cumlprims_mg
   path: cumlprims_mg

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -133,7 +133,7 @@ repos:
         max_device_obj_memory_usage: 3Gi
       args: {cmake: -DBUILD_C_LIBRARY=ON}
   python:
-   - name: libcuvs
+    - name: libcuvs
       sub_dir: python/libcuvs
       depends: [cuvs]
       args: {install: *rapids_build_backend_args}


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/build-planning/issues/33

Adjusts `rapids-build-utils` manifest for release 25.02 to account for the introduction of new `libcuvs` wheels (https://github.com/rapidsai/cuvs/pull/594).

## Notes for Reviewers

This shouldn't be merged still pointing at my forks. Plan:

1. see CI pass here
2. see all CI except devcontainers pass on https://github.com/rapidsai/cuvs/pull/594
3. point this PR back at upstream and admin-merge it
4. re-run devcontainers CI on https://github.com/rapidsai/cuvs/pull/594 and see it pass