### PR TITLE
Revert "Disable CUDA 12.0 RAPIDS builds."

### DIFF
--- a/.github/workflows/build-all-rapids-repos.yml
+++ b/.github/workflows/build-all-rapids-repos.yml
@@ -36,10 +36,7 @@ jobs:
       pull-requests: read
     with:
       arch: '["amd64"]'
-      # Disabling CUDA 12.0 due to failures in cudf builds. See:
-      # https://github.com/rapidsai/devcontainers/pull/438#issuecomment-2596318879
-      #cuda: '["12.0", "12.5"]'
-      cuda: '["12.5"]'
+      cuda: '["12.0", "12.5"]'
       node_type: cpu32
       extra-repo-deploy-key: CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY
       build_command: |


### PR DESCRIPTION
Reverts rapidsai/devcontainers#439

We had disabled these builds due to seg faults that were observed after https://github.com/rapidsai/cudf/pull/17289 was merged. Those should have been fixed after https://github.com/NVIDIA/cuCollections/pull/660 and https://github.com/rapidsai/rapids-cmake/pull/744. https://github.com/rapidsai/cudf/pull/17758 is also relevant but not a direct source for the fix.