### PR TITLE
Use CUDA 12.8 by default in RAPIDS and CUDA features.

### DIFF
--- a/.github/workflows/build-all-rapids-repos.yml
+++ b/.github/workflows/build-all-rapids-repos.yml
@@ -36,7 +36,7 @@ jobs:
       pull-requests: read
     with:
       arch: '["amd64"]'
-      cuda: '["12.5"]'
+      cuda: '["12.8"]'
       node_type: cpu32
       extra-repo-deploy-key: CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY
       build_command: |

--- a/features/src/cuda/README.md
+++ b/features/src/cuda/README.md
@@ -15,7 +15,7 @@ A feature to install the NVIDIA CUDA Toolkit
 
 | Options Id | Description | Type | Default Value |
 |-----|-----|-----|-----|
-| version | Version of the CUDA Toolkit to install. | string | 12.5 |
+| version | Version of the CUDA Toolkit to install. | string | 12.8 |
 | cuDNNVersion | Version of cuDNN to install. | string | 8 |
 | installCompilers | Install NVIDIA CUDA Compiler (nvcc) | boolean | true |
 | installProfilers | Install NVIDIA NSight Systems Profiler (nsys) | boolean | true |

--- a/features/src/cuda/devcontainer-feature.json
+++ b/features/src/cuda/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "CUDA Toolkit",
   "id": "cuda",
-  "version": "25.2.1",
+  "version": "25.2.2",
   "description": "A feature to install the NVIDIA CUDA Toolkit",
   "options": {
     "version": {
@@ -24,7 +24,7 @@
         "11.2",
         "11.1"
       ],
-      "default": "12.5",
+      "default": "12.8",
       "description": "Version of the CUDA Toolkit to install."
     },
     "cuDNNVersion": {

--- a/features/src/cuda/install.sh
+++ b/features/src/cuda/install.sh
@@ -30,7 +30,7 @@ export OSNAME="$(
     echo "$ID$((major - (major % 2)))${minor}";
 )";
 
-VERSION="${CUDA_VERSION:-${VERSION:-12.5.0}}";
+VERSION="${CUDA_VERSION:-${VERSION:-12.8.0}}";
 
 if [[ "$NVARCH" == aarch64 ]]; then
     NVARCH="sbsa";

--- a/features/src/mambaforge/devcontainer-feature.json
+++ b/features/src/mambaforge/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Mambaforge",
   "id": "mambaforge",
-  "version": "25.2.1",
+  "version": "25.2.2",
   "description": "A feature to install mambaforge",
   "options": {
     "version": {

--- a/features/test/_global/cpp_llvm_cuda_nvhpc.sh
+++ b/features/test/_global/cpp_llvm_cuda_nvhpc.sh
@@ -39,11 +39,11 @@ source dev-container-features-test-lib;
 check "gitlab-cli version" glab --version
 
 # Check CUDA
-check "CUDA version" bash -c "echo '$CUDA_VERSION' | grep '12.5.0'";
+check "CUDA version" bash -c "echo '$CUDA_VERSION' | grep '12.8.0'";
 check "CUDA major version" bash -c "echo '$CUDA_VERSION_MAJOR' | grep '12'";
-check "CUDA minor version" bash -c "echo '$CUDA_VERSION_MINOR' | grep '5'";
+check "CUDA minor version" bash -c "echo '$CUDA_VERSION_MINOR' | grep '8'";
 check "CUDA patch version" bash -c "echo '$CUDA_VERSION_PATCH' | grep '0'";
-check "installed" stat /usr/local/cuda-12.5 /usr/local/cuda;
+check "installed" stat /usr/local/cuda-12.8 /usr/local/cuda;
 check "nvcc exists and is on path" which nvcc;
 
 # Check NVHPC

--- a/features/test/_global/cuda_rust.sh
+++ b/features/test/_global/cuda_rust.sh
@@ -40,11 +40,11 @@ source dev-container-features-test-lib;
 >&2 echo "BASH_ENV=$BASH_ENV";
 
 # Check CUDA
-check "CUDA version" bash -c "echo '$CUDA_VERSION' | grep '12.5.0'";
+check "CUDA version" bash -c "echo '$CUDA_VERSION' | grep '12.8.0'";
 check "CUDA major version" bash -c "echo '$CUDA_VERSION_MAJOR' | grep '12'";
-check "CUDA minor version" bash -c "echo '$CUDA_VERSION_MINOR' | grep '5'";
+check "CUDA minor version" bash -c "echo '$CUDA_VERSION_MINOR' | grep '8'";
 check "CUDA patch version" bash -c "echo '$CUDA_VERSION_PATCH' | grep '0'";
-check "installed" stat /usr/local/cuda-12.5 /usr/local/cuda;
+check "installed" stat /usr/local/cuda-12.8 /usr/local/cuda;
 check "nvcc exists and is on path" which nvcc;
 
 # Check Rust

--- a/features/test/_global/scenarios.json
+++ b/features/test/_global/scenarios.json
@@ -4,7 +4,7 @@
     "features": {
       "rust": {},
       "cuda": {
-        "version": "12.5"
+        "version": "12.8"
       }
     },
     "overrideFeatureInstallOrder": [
@@ -44,7 +44,7 @@
         "version": "16"
       },
       "cuda": {
-        "version": "12.5"
+        "version": "12.8"
       },
       "nvhpc": {
         "version": "24.5"

--- a/features/test/cuda/test.sh
+++ b/features/test/cuda/test.sh
@@ -17,11 +17,11 @@ source dev-container-features-test-lib
 
 # Feature-specific tests
 # The 'check' command comes from the dev-container-features-test-lib.
-check "CUDA version" bash -c "echo '$CUDA_VERSION' | grep '12.5.0'";
+check "CUDA version" bash -c "echo '$CUDA_VERSION' | grep '12.8.0'";
 check "CUDA major version" bash -c "echo '$CUDA_VERSION_MAJOR' | grep '12'";
-check "CUDA minor version" bash -c "echo '$CUDA_VERSION_MINOR' | grep '5'";
+check "CUDA minor version" bash -c "echo '$CUDA_VERSION_MINOR' | grep '8'";
 check "CUDA patch version" bash -c "echo '$CUDA_VERSION_PATCH' | grep '0'";
-check "installed" stat /usr/local/cuda-12.5 /usr/local/cuda
+check "installed" stat /usr/local/cuda-12.8 /usr/local/cuda
 check "nvcc exists and is on path" which nvcc
 
 # Report result

--- a/features/test/openmpi/scenarios.json
+++ b/features/test/openmpi/scenarios.json
@@ -3,7 +3,7 @@
     "image": "ubuntu:22.04",
     "features": {
       "cuda": {
-        "version": "12.5"
+        "version": "12.8"
       },
       "ucx": {
         "version": "1.15.0"

--- a/features/test/ucx/scenarios.json
+++ b/features/test/ucx/scenarios.json
@@ -3,7 +3,7 @@
     "image": "ubuntu:22.04",
     "features": {
       "cuda": {
-        "version": "12.5"
+        "version": "12.8"
       },
       "ucx": {
         "version": "1.14.1"
@@ -18,7 +18,7 @@
     "image": "ubuntu:22.04",
     "features": {
       "cuda": {
-        "version": "12.5"
+        "version": "12.8"
       },
       "ucx": {
         "version": "1.15.0-rc3"

--- a/matrix.yml
+++ b/matrix.yml
@@ -2,7 +2,7 @@ x-cuda-prev-min: &cuda_prev_min { name: "cuda", version: "11.1" }
 x-cuda-prev-max: &cuda_prev_max { name: "cuda", version: "11.8" }
 x-cuda-curr-min: &cuda_curr_min { name: "cuda", version: "12.0" }
 x-cuda-curr-max: &cuda_curr_max { name: "cuda", version: "12.8" }
-x-cuda-curr-max-rapids: &cuda_curr_max_rapids { name: "cuda", version: "12.5" }
+x-cuda-curr-max-rapids: &cuda_curr_max_rapids { name: "cuda", version: "12.8" }
 
 x-gcc-7: &gcc_7 { name: "gcc", version: "7" }
 x-gcc-8: &gcc_8 { name: "gcc", version: "8" }

--- a/windows/image/installers/install-cuda.ps1
+++ b/windows/image/installers/install-cuda.ps1
@@ -1,7 +1,7 @@
 Param(
     [Parameter(Mandatory=$false)]
     [string]
-    $cudaVersion="12.5.0"
+    $cudaVersion="12.8.0"
 )
 
 # Use System.Version to tokenize version
@@ -11,7 +11,7 @@ $major = $version.Major
 $minor = $version.Minor
 $build = $version.Build
 
-# Minimum build is 0, not -1 as default in case "12.5" is passed
+# Minimum build is 0, not -1 as default in case "12.8" is passed
 if ($build -lt 0) {
     $build = 0
 }


### PR DESCRIPTION
Now that RAPIDS has fully migrated to CUDA 12.8, we can change the defaults in our devcontainers.
