### PR TITLE
Fix package names in manifest for dask-cudf and cudf-polars

### DIFF
--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -83,10 +83,10 @@ repos:
       sub_dir: python/cudf
       depends: [cudf]
       args: {install: *rapids_build_backend_args}
-    - name: dask_cudf
+    - name: dask-cudf
       sub_dir: python/dask_cudf
       args: {install: *rapids_build_backend_args}
-    - name: cudf_polars
+    - name: cudf-polars
       sub_dir: python/cudf_polars
       args: {install: *rapids_build_backend_args}
     - name: cudf_kafka


### PR DESCRIPTION
Although the subdirectories have underscores, the advertised package names have hyphens. Without this, we end up depending on dask-cudf in the combined conda dev environment that then pulls in cudf. sadtimes.gif