### PR TITLE
Update windows CMake version to 3.31.6.

### DIFF
--- a/windows/image/installers/install-cmake.ps1
+++ b/windows/image/installers/install-cmake.ps1
@@ -1,5 +1,5 @@
 # Fetch CMake
-Invoke-WebRequest -Uri "https://github.com/Kitware/CMake/releases/download/v3.27.6/cmake-3.27.6-windows-x86_64.msi" -OutFile "C:\cmake_installer.msi" -UseBasicParsing
+Invoke-WebRequest -Uri "https://github.com/Kitware/CMake/releases/download/v3.31.6/cmake-3.31.6-windows-x86_64.msi" -OutFile "C:\cmake_installer.msi" -UseBasicParsing
 Start-Process -NoNewWindow -Wait -FilePath msiexec -ArgumentList "/i C:\cmake_installer.msi ADD_CMAKE_TO_PATH=All /qn"
 Remove-Item "C:\cmake_installer.msi"
 


### PR DESCRIPTION
Required as part of updating nvbench's CI, since rapids-cmake requires at least 3.30.