### PR TITLE
Misc shell script clean up

### DIFF
--- a/features/src/cccl-dev/devcontainer-feature.json
+++ b/features/src/cccl-dev/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA CCCL development utilities",
   "id": "cccl-dev",
-  "version": "25.6.0",
+  "version": "25.6.1",
   "description": "A feature to install NVIDIA CCCL development utilities",
   "options": {
     "litVersion": {

--- a/features/src/cccl-dev/install.sh
+++ b/features/src/cccl-dev/install.sh
@@ -15,7 +15,7 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
 # install global/common scripts
 . ./common/install.sh;
 
-if ! type python >/dev/null 2>&1; then
+if ! command -v python >/dev/null 2>&1; then
   echo "lit feature expects python to already be installed" >&2;
   exit 1;
 fi
@@ -25,8 +25,8 @@ PKG_TO_REMOVE=();
 
 # Install gcc and g++ because we have to build psutil wheel for non-x86
 if [[ "$(uname -p)" != "x86_64" ]]; then
-    if ! type gcc >/dev/null 2>&1; then PKG_TO_REMOVE+=("gcc"); fi
-    if ! type g++ >/dev/null 2>&1; then PKG_TO_REMOVE+=("g++"); fi
+    if ! command -v gcc >/dev/null 2>&1; then PKG_TO_REMOVE+=("gcc"); fi
+    if ! command -v g++ >/dev/null 2>&1; then PKG_TO_REMOVE+=("g++"); fi
 fi
 
 check_packages "${PKG[@]}" "${PKG_TO_REMOVE[@]}";

--- a/features/src/cuda/devcontainer-feature.json
+++ b/features/src/cuda/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "CUDA Toolkit",
   "id": "cuda",
-  "version": "25.6.0",
+  "version": "25.6.1",
   "description": "A feature to install the NVIDIA CUDA Toolkit",
   "options": {
     "version": {

--- a/features/src/cuda/install.sh
+++ b/features/src/cuda/install.sh
@@ -224,7 +224,7 @@ if ! test -L "${CUDA_HOME}"; then
     ln -s "${cudapath}" "${CUDA_HOME}";
 fi
 
-if test -z "${CUDA_VERSION:-}"; then
+if ! test -n "${CUDA_VERSION:+x}"; then
     if test -f "${CUDA_HOME}/include/cuda.h"; then
         cuda_ver=$(grep "#define CUDA_VERSION" "${CUDA_HOME}/include/cuda.h" | cut -d' ' -f3);
         CUDA_VERSION_MAJOR=$((cuda_ver / 1000));

--- a/features/src/cuda/prune-extra-cutensor-libs.sh
+++ b/features/src/cuda/prune-extra-cutensor-libs.sh
@@ -2,7 +2,7 @@
 libcutensor_ver="$(dpkg -s libcutensor1 | grep '^Version:' | cut -d' ' -f2 | cut -d'-' -f1 | cut -d'.' -f4 --complement)";
 libcutensorMg_shared="$(find /usr/lib -type f -regex "^.*/libcutensor/${CUDA_VERSION_MAJOR}/libcutensorMg.so.${libcutensor_ver}$")";
 
-if test -n "${libcutensorMg_shared:-}"; then
+if test -n "${libcutensorMg_shared:+x}"; then
 
     libcutensorMg_shared="$(find /usr/lib -type f -regex "^.*/libcutensor/${CUDA_VERSION_MAJOR}/libcutensorMg.so.${libcutensor_ver}$")";
     libcutensorMg_static="$(find /usr/lib -type f -regex "^.*/libcutensor/${CUDA_VERSION_MAJOR}/libcutensorMg_static.a$")";
@@ -18,29 +18,29 @@ if test -n "${libcutensorMg_shared:-}"; then
     # 2. Install only the alternative for the version we keep
     # 3. Set the default alternatives
 
-    if test -n "${libcutensorMg_shared}" && test -f "${libcutensorMg_shared}" \
-    && test -n "${libcutensorMg_shared_link}" && test -L "${libcutensorMg_shared_link}"; then
+    if test -n "${libcutensorMg_shared:+x}" && test -f "${libcutensorMg_shared}" \
+    && test -n "${libcutensorMg_shared_link:+x}" && test -L "${libcutensorMg_shared_link}"; then
         (update-alternatives --remove-all libcutensorMg.so.${libcutensor_ver} >/dev/null 2>&1 || true);
         update-alternatives --install "${libcutensorMg_shared_link}" libcutensorMg.so.${libcutensor_ver} "${libcutensorMg_shared}" 0;
         update-alternatives --set libcutensorMg.so.${libcutensor_ver} "${libcutensorMg_shared}";
     fi
 
-    if test -n "${libcutensorMg_static}" && test -f "${libcutensorMg_static}" \
-    && test -n "${libcutensorMg_static_link}" && test -L "${libcutensorMg_static_link}"; then
+    if test -n "${libcutensorMg_static:+x}" && test -f "${libcutensorMg_static}" \
+    && test -n "${libcutensorMg_static_link:+x}" && test -L "${libcutensorMg_static_link}"; then
         (update-alternatives --remove-all libcutensorMg_static.a              >/dev/null 2>&1 || true);
         update-alternatives --install "${libcutensorMg_static_link}" libcutensorMg_static.a "${libcutensorMg_static}" 0;
         update-alternatives --set libcutensorMg_static.a "${libcutensorMg_static}";
     fi
 
-    if test -n "${libcutensor_shared}" && test -f "${libcutensor_shared}" \
-    && test -n "${libcutensor_shared_link}" && test -L "${libcutensor_shared_link}"; then
+    if test -n "${libcutensor_shared:+x}" && test -f "${libcutensor_shared}" \
+    && test -n "${libcutensor_shared_link:+x}" && test -L "${libcutensor_shared_link}"; then
         (update-alternatives --remove-all libcutensor.so.${libcutensor_ver}   >/dev/null 2>&1 || true);
         update-alternatives --install "${libcutensor_shared_link}" libcutensor.so.${libcutensor_ver} "${libcutensor_shared}" 0;
         update-alternatives --set libcutensor.so.${libcutensor_ver} "${libcutensor_shared}";
     fi
 
-    if test -n "${libcutensor_static}" && test -f "${libcutensor_static}" \
-    && test -n "${libcutensor_static_link}" && test -L "${libcutensor_static_link}"; then
+    if test -n "${libcutensor_static:+x}" && test -f "${libcutensor_static}" \
+    && test -n "${libcutensor_static_link:+x}" && test -L "${libcutensor_static_link}"; then
         (update-alternatives --remove-all libcutensor_static.a                >/dev/null 2>&1 || true);
         update-alternatives --install "${libcutensor_static_link}" libcutensor_static.a "${libcutensor_static}" 0;
         update-alternatives --set libcutensor_static.a "${libcutensor_static}";

--- a/features/src/cuda/prune-static-libs.sh
+++ b/features/src/cuda/prune-static-libs.sh
@@ -1,9 +1,9 @@
-if test -n "${libcutensorMg_static:-}" && test -f "${libcutensorMg_static}"; then
+if test -n "${libcutensorMg_static:+x}" && test -f "${libcutensorMg_static}"; then
     rm -rf "${libcutensorMg_static}";
     (update-alternatives --remove-all libcutensorMg_static.a >/dev/null 2>&1 || true);
 fi
 
-if test -n "${libcutensor_static:-}" && test -f "${libcutensor_static}"; then
+if test -n "${libcutensor_static:+x}" && test -f "${libcutensor_static}"; then
     rm -rf "${libcutensor_static}";
     (update-alternatives --remove-all libcutensor_static.a   >/dev/null 2>&1 || true);
 fi

--- a/features/src/gitlab-cli/devcontainer-feature.json
+++ b/features/src/gitlab-cli/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "gitlab-cli",
-  "version": "25.6.0",
+  "version": "25.6.1",
   "name": "GitLab CLI",
   "documentationURL": "https://github.com/rapidsai/devcontainers/features/tree/main/src/gitlab-cli",
   "description": "Installs the GitLab CLI. Auto-detects latest version and installs needed dependencies.",

--- a/features/src/gitlab-cli/install.sh
+++ b/features/src/gitlab-cli/install.sh
@@ -65,7 +65,7 @@ export DEBIAN_FRONTEND=noninteractive;
 
 # Install curl, ca-certificates, apt-transport-https, and git (if missing)
 check_packages curl ca-certificates apt-transport-https;
-if ! type git >/dev/null 2>&1; then
+if ! command -v git >/dev/null 2>&1; then
     check_packages git;
 fi
 
@@ -77,7 +77,7 @@ install_deb_using_gitlab;
 glab config set -g check_update false;
 
 if dpkg -s bash-completion >/dev/null 2>&1; then
-    if type glab >/dev/null 2>&1; then
+    if command -v glab >/dev/null 2>&1; then
         glab completion -s bash | tee /etc/bash_completion.d/glab >/dev/null;
     fi
 fi

--- a/features/src/llvm/devcontainer-feature.json
+++ b/features/src/llvm/devcontainer-feature.json
@@ -39,7 +39,7 @@
   "updateContentCommand": [
     "/bin/bash",
     "-c",
-    "mkdir -m 0755 -p ~/.config/clangd && cp -n /etc/skel/.config/clangd/config.yaml ~/.config/clangd/config.yaml"
+    "mkdir -m 0755 -p ~/.config/clangd && cp -u /etc/skel/.config/clangd/config.yaml ~/.config/clangd/config.yaml"
   ],
   "customizations": {
     "vscode": {

--- a/features/src/llvm/devcontainer-feature.json
+++ b/features/src/llvm/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "LLVM compilers and tools",
   "id": "llvm",
-  "version": "25.6.0",
+  "version": "25.6.1",
   "description": "A feature to install LLVM compilers and tools",
   "options": {
     "version": {

--- a/features/src/llvm/install.sh
+++ b/features/src/llvm/install.sh
@@ -61,7 +61,7 @@ fi
 # Remove existing, install, and set default clang/llvm alternatives
 for ((i=0; i < ${#bins[@]}; i+=1)); do
     x=${bins[$i]};
-    if type "${x}-${LLVM_VERSION}" >/dev/null 2>&1; then
+    if command -v "${x}-${LLVM_VERSION}" >/dev/null 2>&1; then
         (update-alternatives --install /usr/bin/"${x}" "${x}" "$(which "${x}-${LLVM_VERSION}")" 30);
         (update-alternatives --set "${x}" "$(which "${x}-${LLVM_VERSION}")");
     fi

--- a/features/src/mambaforge/.bashrc
+++ b/features/src/mambaforge/.bashrc
@@ -13,7 +13,7 @@ unset nounseton;
 
 if [ -n "${CONDA_EXE:-}" ]; then
     conda_bin_paths="$(dirname "$(dirname "${CONDA_EXE}")")/condabin";
-    if test -n "${CONDA_PREFIX:-}"; then
+    if test -n "${CONDA_PREFIX:+x}"; then
         conda_bin_paths="${conda_bin_paths} ${CONDA_PREFIX}/bin";
     fi
     for conda_bin_path in ${conda_bin_paths}; do

--- a/features/src/mambaforge/devcontainer-feature.json
+++ b/features/src/mambaforge/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Mambaforge",
   "id": "mambaforge",
-  "version": "25.6.0",
+  "version": "25.6.1",
   "description": "A feature to install mambaforge",
   "options": {
     "version": {

--- a/features/src/mambaforge/install.sh
+++ b/features/src/mambaforge/install.sh
@@ -36,7 +36,7 @@ conda clean --force-pkgs-dirs --all --yes;
 # Activate conda in /etc/bash.bashrc
 append_to_etc_bashrc "$(cat<< EOF
 for x in "conda" "mamba"; do
-    if ! type \$x 2>&1 | grep -q function; then . /opt/conda/etc/profile.d/\$x.sh; fi;
+    if ! command -v \$x 2>&1 | grep -q function; then . /opt/conda/etc/profile.d/\$x.sh; fi;
 done
 $(cat .bashrc)
 EOF
@@ -44,7 +44,7 @@ EOF
 # Activate conda in ~/.bashrc
 append_to_all_bashrcs "$(cat<< EOF
 for x in "conda" "mamba"; do
-    if ! type \$x 2>&1 | grep -q function; then . /opt/conda/etc/profile.d/\$x.sh; fi;
+    if ! command -v \$x 2>&1 | grep -q function; then . /opt/conda/etc/profile.d/\$x.sh; fi;
 done
 $(cat .bashrc)
 EOF

--- a/features/src/nvhpc/devcontainer-feature.json
+++ b/features/src/nvhpc/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVHPC SDK",
   "id": "nvhpc",
-  "version": "25.6.0",
+  "version": "25.6.1",
   "description": "A feature to install the NVHPC SDK",
   "options": {
     "version": {

--- a/features/src/nvhpc/etc/profile.d/nvhpc.sh
+++ b/features/src/nvhpc/etc/profile.d/nvhpc.sh
@@ -1,4 +1,4 @@
-if ! type module 2>&1 | grep -q function; then
+if ! command -v module 2>&1 | grep -q function; then
     . /etc/profile.d/lmod._sh;
 fi
 

--- a/features/src/oneapi/devcontainer-feature.json
+++ b/features/src/oneapi/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Intel oneapi toolchain",
   "id": "oneapi",
-  "version": "25.6.0",
+  "version": "25.6.1",
   "description": "A feature to install the Intel oneapi toolchain",
   "options": {
     "version": {

--- a/features/src/oneapi/etc/profile.d/oneapi.sh
+++ b/features/src/oneapi/etc/profile.d/oneapi.sh
@@ -1,4 +1,4 @@
-if ! type module 2>&1 | grep -q function; then
+if ! command -v module 2>&1 | grep -q function; then
     . /etc/profile.d/lmod._sh;
 fi
 

--- a/features/src/openmpi/devcontainer-feature.json
+++ b/features/src/openmpi/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "OpenMPI",
   "id": "openmpi",
-  "version": "25.6.0",
+  "version": "25.6.1",
   "description": "A feature to install OpenMPI with optional CUDA and UCX support",
   "options": {
     "version": {

--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "25.6.0",
+  "version": "25.6.1",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/install.sh
+++ b/features/src/rapids-build-utils/install.sh
@@ -9,7 +9,7 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
 
 PKGS=(bc jq pigz sudo wget gettext-base bash-completion ca-certificates);
 
-if ! type /usr/bin/python3 >/dev/null 2>&1; then
+if ! command -v /usr/bin/python3 >/dev/null 2>&1; then
     PKGS+=(python3 python3-pip);
 elif ! /usr/bin/python3 -m pip >/dev/null 2>&1; then
     PKGS+=(python3-pip);
@@ -18,7 +18,7 @@ fi
 check_packages "${PKGS[@]}";
 
 # Install yq if not installed
-if ! type yq >/dev/null 2>&1; then
+if ! command -v yq >/dev/null 2>&1; then
     YQ_BINARY="yq";
     YQ_BINARY+="_$(uname -s | tr '[:upper:]' '[:lower:]')";
     YQ_BINARY+="_${TARGETARCH:-$(dpkg --print-architecture | awk -F'-' '{print $NF}')}";
@@ -95,7 +95,7 @@ for cmd in "${commands[@]}"; do
 done
 
 # Install bash_completion script
-if type devcontainer-utils-generate-bash-completion >/dev/null 2>&1; then
+if command -v devcontainer-utils-generate-bash-completion >/dev/null 2>&1; then
     devcontainer-utils-generate-bash-completion                          \
         --out-file /etc/bash_completion.d/rapids-build-utils-completions \
         ${commands[@]/#/--command rapids-}                               \

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/generate-scripts.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/generate-scripts.sh
@@ -12,7 +12,7 @@ generate_completions() {
     local -;
     set -euo pipefail;
 
-    if type devcontainer-utils-debug-output >/dev/null 2>&1; then
+    if command -v devcontainer-utils-debug-output >/dev/null 2>&1; then
         # shellcheck disable=SC1091
         . devcontainer-utils-debug-output 'rapids_build_utils_debug' 'generate-scripts';
 
@@ -30,7 +30,7 @@ clean_scripts_and_aliases() {
     local -;
     set -euo pipefail;
 
-    if type devcontainer-utils-debug-output >/dev/null 2>&1; then
+    if command -v devcontainer-utils-debug-output >/dev/null 2>&1; then
         # shellcheck disable=SC1091
         . devcontainer-utils-debug-output 'rapids_build_utils_debug' 'generate-scripts';
     fi
@@ -158,7 +158,7 @@ generate_scripts() {
 
     eval "$(rapids-list-repos "$@")";
 
-    if type devcontainer-utils-debug-output >/dev/null 2>&1; then
+    if command -v devcontainer-utils-debug-output >/dev/null 2>&1; then
         # shellcheck disable=SC1091
         . devcontainer-utils-debug-output 'rapids_build_utils_debug' 'generate-scripts';
     fi

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/generate-scripts.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/generate-scripts.sh
@@ -43,7 +43,7 @@ clean_scripts_and_aliases() {
 
 generate_script() {
     local bin="${1:-}";
-    if test -n "${bin}"; then
+    if test -n "${bin:+x}"; then
         (
             cat - \
           | envsubst '$HOME $NAME $SRC_PATH $PY_ENV $PY_SRC $PY_LIB $BIN_DIR $CPP_ENV $CPP_LIB $CPP_SRC $CPP_CMAKE_ARGS $CPP_CPACK_ARGS $CPP_DEPS $CPP_MAX_TOTAL_SYSTEM_MEMORY $CPP_MAX_DEVICE_OBJ_MEMORY_USAGE $CPP_MAX_DEVICE_OBJ_TO_COMPILE_IN_PARALLEL $GIT_TAG $GIT_SSH_URL $GIT_HTTPS_URL $GIT_REPO $GIT_HOST $GIT_UPSTREAM $PIP_WHEEL_ARGS $PIP_INSTALL_ARGS' \
@@ -64,7 +64,7 @@ generate_script() {
 
 generate_all_script_impl() {
     local bin="${SCRIPT}-all";
-    if test -n "${bin}" && ! test -f "${TMP_SCRIPT_DIR}/${bin}"; then
+    if test -n "${bin:+x}" && ! test -f "${TMP_SCRIPT_DIR}/${bin}"; then
         (
             cat - \
           | envsubst '$NAME $NAMES $SCRIPT' \

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/get-cmake-build-dir.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/get-cmake-build-dir.sh
@@ -40,7 +40,7 @@ get_cmake_build_dir() {
 
     local src="${REST[0]:-}";
 
-    if test -n "${src}" && rapids-python-uses-scikit-build "${src}"; then
+    if test -n "${src:+x}" && rapids-python-uses-scikit-build "${src}"; then
         echo "${src:+${src}/}$(python -c 'from skbuild import constants; print(constants.CMAKE_BUILD_DIR())')";
     else
         local -r type="$(rapids-select-cmake-build-type "${OPTS[@]}" "${REST[@]:1}" | tr '[:upper:]' '[:lower:]')";
@@ -48,10 +48,10 @@ get_cmake_build_dir() {
         local bin="build";
         bin+="${PYTHON_PACKAGE_MANAGER:+/${PYTHON_PACKAGE_MANAGER}}${cuda:+/cuda-${cuda}}";
 
-        if test -n "${src:-}" && test -d "${src:-}"; then
+        if test -n "${src:+x}" && test -d "${src:-}"; then
             mkdir -p "${src}/${bin}";
-            if  test -z "${skip_links-}"; then
-                if test -z "${skip_build_type-}" || ! test -L "${src}/${bin}/latest"; then
+            if  ! test -n "${skip_links:+x}"; then
+                if ! test -n "${skip_build_type:+x}" || ! test -L "${src}/${bin}/latest"; then
                     mkdir -p "${src}/${bin}/${type}";
                     cd "${src}/${bin}/" || exit 1;
                     ln -sfn "${type}" latest;
@@ -59,7 +59,7 @@ get_cmake_build_dir() {
                 cd "${src}/build" || exit 1;
                 local component;
                 for component in "${PYTHON_PACKAGE_MANAGER:-}" "${cuda:+cuda-${cuda}}"; do
-                    if test -n "${component:-}"; then
+                    if test -n "${component:+x}"; then
                         ln -sfn "${component}/latest" latest;
                         cd "${component}" || exit 1;
                     fi
@@ -67,7 +67,7 @@ get_cmake_build_dir() {
             fi
         fi
 
-        if test -n "${skip_build_type-}"; then
+        if test -n "${skip_build_type:+x}"; then
             echo "${src:+${src}/}${bin}/latest";
         else
             echo "${src:+${src}/}${bin}/${type}";

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/get-num-archs-jobs-and-load.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/get-num-archs-jobs-and-load.sh
@@ -46,7 +46,7 @@ get_num_archs_jobs_and_load() {
     # Since we want the physical number of processors here, pass --all
     local -r n_cpus="$(nproc --all)";
 
-    if test ${#j[@]} -gt 0 && test -z "${j:-}"; then
+    if test ${#j[@]} -gt 0 && ! test -n "${j:+x}"; then
         j="${n_cpus}";
     fi
 
@@ -69,8 +69,7 @@ get_num_archs_jobs_and_load() {
     # see: https://github.com/rapidsai/rapids-cmake/blob/branch-24.04/rapids-cmake/cuda/set_architectures.cmake#L54
     local n_arch_rapids=5;
 
-    if test -z "${archs:-}" \
-    && test -n "${INFER_NUM_DEVICE_ARCHITECTURES:-}"; then
+    if ! test -n "${archs:+x}" && test -n "${INFER_NUM_DEVICE_ARCHITECTURES:+x}"; then
         archs="$(rapids-select-cmake-define CMAKE_CUDA_ARCHITECTURES "${OPTS[@]}" || echo)";
         archs="${archs:-${CMAKE_CUDA_ARCHITECTURES:-${CUDAARCHS:-}}}";
 
@@ -105,7 +104,7 @@ get_num_archs_jobs_and_load() {
     local mem_for_device_objs="$((n_arch * max_device_obj_memory_usage))";
     local mem_total="${max_total_system_memory:-${MAX_TOTAL_SYSTEM_MEMORY:-}}";
 
-    if test -z "${mem_total}"; then
+    if ! test -n "${mem_total:+x}"; then
         local -r free_mem="$(free --bytes | grep -E '^Mem:' | tr -s '[:space:]' | cut -d' ' -f7 || echo '0')";
         local -r freeswap="$(free --bytes | grep -E '^Swap:' | tr -s '[:space:]' | cut -d' ' -f4 || echo '0')";
         mem_total="$((free_mem + freeswap))";

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/list-repos.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/list-repos.sh
@@ -46,7 +46,7 @@ list_repos() {
         filters+=("| map(select(${omit[@]} true))");
     fi
 
-    if test -n "${filters:-}"; then
+    if test -n "${filters:+x}"; then
         query=".repos ${filters[*]} | {repos: .}";
     fi
 

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-env.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-env.sh
@@ -46,7 +46,7 @@ make_conda_env() {
             cat "${new_env_path}";
             echo "";
 
-            conda env create -n "${env_name}" -f "${new_env_path}" --solver=libmamba;
+            conda env create -q -n "${env_name}" -f "${new_env_path}" --solver=libmamba;
         # If the conda env does exist but it's different from the generated one,
         # print the diff between the envs and update it
         elif ! diff -BNqw "${old_env_path}" "${new_env_path}" >/dev/null 2>&1; then
@@ -65,7 +65,7 @@ make_conda_env() {
             # We mount in the package cache, so this should still be fast in most cases.
             rm -rf "${HOME}/.conda/envs/${env_name}";
 
-            conda env create -n "${env_name}" -f "${new_env_path}" --solver=libmamba;
+            conda env create -q -n "${env_name}" -f "${new_env_path}" --solver=libmamba;
         fi
 
         cp -a "${new_env_path}" "${old_env_path}";

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-env.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-env.sh
@@ -27,7 +27,7 @@ make_conda_env() {
     local env_file_name="${env_name}.yml";
 
     # Remove the current conda env if called with `-f,--force`
-    if test -n "${f-}"; then
+    if test -n "${f:+x}"; then
         rm -rf "${HOME}/.conda/envs/${env_name}" \
                "${HOME}/.conda/envs/${env_file_name}";
     fi

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-pip-dependencies.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-pip-dependencies.sh
@@ -194,7 +194,7 @@ make_pip_dependencies() {
         cat "${requirement[@]}" "${pip_reqs_txts[@]}"                                                           \
       | (grep -v '^#' || [ "$?" == "1" ])                                                                       \
       | (grep -v -E '^$' || [ "$?" == "1" ])                                                                    \
-      | ( if test -n "${no_dedupe-}"; then cat -; else tr -s "[:blank:]" | LC_ALL=C sort -u; fi )               \
+      | ( if test -n "${no_dedupe:+x}"; then cat -; else tr -s "[:blank:]" | LC_ALL=C sort -u; fi )             \
       | (grep -v -P "^($(tr -d '[:blank:]' <<< "${pip_noinstall[@]/%/|}"))(=.*|>.*|<.*)?$" || [ "$?" == "1" ])  \
       | ( if test ${#_exclude[@]} -gt 0; then grep -E -v "${_exclude[@]}" || [ "$?" == "1" ]; else cat -; fi )  \
       | ( if test ${#_include[@]} -gt 0; then grep -E    "${_include[@]}" || [ "$?" == "1" ]; else cat -; fi )  \

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-pip-env.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-pip-env.sh
@@ -29,7 +29,7 @@ make_pip_env() {
 
     test ${#pre[@]} -eq 0 && pre=(--pre);
 
-    if test -n "${no_pre-}"; then
+    if test -n "${no_pre:+x}"; then
         pre=();
     fi
 
@@ -37,7 +37,7 @@ make_pip_env() {
     local env_file_name="${env_name}.requirements.txt";
 
     # Remove the current virtual env if called with `-f,--force`
-    if test -n "${f-}"; then
+    if test -n "${f:+x}"; then
         rm -rf "${HOME}/.local/share/venvs/${env_name}" \
                "${HOME}/.local/share/venvs/${env_file_name}";
     fi

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-vscode-workspace.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-vscode-workspace.sh
@@ -75,7 +75,7 @@ make_vscode_workspace() {
     local -;
     set -euo pipefail;
 
-    if type devcontainer-utils-debug-output >/dev/null 2>&1; then
+    if command -v devcontainer-utils-debug-output >/dev/null 2>&1; then
         # shellcheck disable=SC1091
         . devcontainer-utils-debug-output 'rapids_build_utils_debug' 'make-vscode-workspace';
     fi

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/maybe-clean-build-dir.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/maybe-clean-build-dir.sh
@@ -27,7 +27,7 @@ maybe_clean_build_dir() {
 
     local -r bin_dir="$(rapids-get-cmake-build-dir "${OPTS[@]}" "${REST[@]}")";
 
-    if test -n "${bin_dir-}" && test -d "${bin_dir}"; then
+    if test -n "${bin_dir:+x}" && test -d "${bin_dir}"; then
         case "${G:-Ninja}" in
             "Unix Makefiles")
                 test -f "${bin_dir}/Makefile" || rm -rf "${bin_dir}";;

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/post-start-command.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/post-start-command.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
-if test -z "${SKIP_RAPIDS_BUILD_UTILS_POST_START_COMMAND:-}"; then
+if ! test -n "${SKIP_RAPIDS_BUILD_UTILS_POST_START_COMMAND:+x}"; then
     rapids-generate-scripts;
     rapids-update-build-dir-links -j;
     rapids-make-vscode-workspace --update;
     rapids-merge-compile-commands-json > ~/compile_commands.json;
-    if test -n "${PYTHON_PACKAGE_MANAGER:-}"; then
+    if test -n "${PYTHON_PACKAGE_MANAGER:+x}"; then
         rapids-make-"${PYTHON_PACKAGE_MANAGER}"-env "$@" || true;
     fi
 fi

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/post-start-command.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/post-start-command.sh
@@ -2,7 +2,7 @@
 
 if test -z "${SKIP_RAPIDS_BUILD_UTILS_POST_START_COMMAND:-}"; then
     rapids-generate-scripts;
-    rapids-update-build-dir-links;
+    rapids-update-build-dir-links -j;
     rapids-make-vscode-workspace --update;
     rapids-merge-compile-commands-json > ~/compile_commands.json;
     if test -n "${PYTHON_PACKAGE_MANAGER:-}"; then

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/pull-repositories.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/pull-repositories.sh
@@ -49,11 +49,11 @@ pull_repositories() {
         local branch="$(git -C ~/${!repo_path} rev-parse --abbrev-ref HEAD)";
 
         while true; do
-            if test -n "${branch:-}" \
+            if test -n "${branch:+x}" \
             && git -C ~/${!repo_path} branch -r | grep "${remote}/${branch}"; then
                 break;
             fi
-            if test -n "${default_branch:-}" \
+            if test -n "${default_branch:+x}" \
             && git -C ~/${!repo_path} branch -r | grep "${remote}/${default_branch}"; then
                 branch="${default_branch}";
                 break;
@@ -64,7 +64,7 @@ pull_repositories() {
             read -rp "
 ############################################################
 $(
-    test -z "${default_branch:-}" && \
+  ! test -n "${default_branch:+x}" && \
     echo "Branch \"${branch}\" " || \
     echo "Branches \"${branch}\" and \"${default_branch}\" "
 )\
@@ -74,13 +74,13 @@ ${remote_info}
 
 Please enter a branch name to pull (or leave empty to skip): " branch </dev/tty
 
-            if test -z "${branch:-}"; then
+            if ! test -n "${branch:+x}"; then
                 echo "No alternate branch name supplied, skipping";
                 break;
             fi
         done
 
-        if test -n "${branch:-}"; then
+        if test -n "${branch:+x}"; then
             echo "Pulling ${!repo_name} ${remote}/${branch}...";
             git -C ~/${!repo_path} pull --no-tags "${remote}" "${branch}";
             git -C ~/${!repo_path} submodule update --init --recursive;

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/select-cmake-define.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/select-cmake-define.sh
@@ -29,7 +29,7 @@ parse_cmake_define() {
             val="${arg#*=}";
         fi
     done
-    test -n "${val:-}" && echo "${val}";
+    test -n "${val:+x}" && echo "${val}";
 }
 
 parse_cmake_define "$@" <&0;

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.build.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.build.tmpl.sh
@@ -22,7 +22,7 @@ build_all() {
     . devcontainer-utils-debug-output 'rapids_build_utils_debug' 'build-all';
 
     for name in ${NAMES}; do
-        if type build-${name} >/dev/null 2>&1; then
+        if command -v build-${name} >/dev/null 2>&1; then
             build-${name} "${OPTS[@]}";
         fi
     done

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.clean.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.clean.tmpl.sh
@@ -31,7 +31,7 @@ clean_all() {
     echo ${NAMES} \
   | tr '[:space:]' '\0' \
   | xargs ${v:+-t} -r -0 -P${n_jobs} -I% bash -c "
-    if type clean-% >/dev/null 2>&1; then
+    if command -v clean-% >/dev/null 2>&1; then
         clean-% ${OPTS[*]} || exit 255;
     fi
     ";

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.clean.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.clean.tmpl.sh
@@ -21,7 +21,7 @@ clean_all() {
     local -;
     set -euo pipefail;
 
-    eval "$(_parse_args --take '-j,--parallel' "$@" <&0)";
+    eval "$(_parse_args --take '-j,--parallel -v,--verbose' "$@" <&0)";
 
     eval "$(rapids-get-num-archs-jobs-and-load --archs 0 "$@")";
 
@@ -30,11 +30,8 @@ clean_all() {
 
     echo ${NAMES} \
   | tr '[:space:]' '\0' \
-  | xargs ${v:+-t} -r -0 -P${n_jobs} -I% bash -c "
-    if command -v clean-% >/dev/null 2>&1; then
-        clean-% ${OPTS[*]} || exit 255;
-    fi
-    ";
+  | xargs ${v:+-t} -r -0 -P${n_jobs} -I% bash -c \
+  " if command -v clean-% >/dev/null 2>&1; then if ! clean-% ${OPTS[*]@Q} ${v[*]@Q}; then exit 255; fi; fi";
 }
 
 clean_all "$@" <&0;

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.clone.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.clone.tmpl.sh
@@ -21,7 +21,7 @@ clone_all() {
     local -;
     set -euo pipefail;
 
-    eval "$(_parse_args --take '-j,--parallel --no-update-env' "$@" <&0)";
+    eval "$(_parse_args --take '-j,--parallel -v,--verbose --no-update-env' "$@" <&0)";
 
     eval "$(rapids-get-num-archs-jobs-and-load --archs 3 --max-device-obj-memory-usage 1 "$@")";
 
@@ -35,11 +35,8 @@ clone_all() {
 
     echo ${NAMES} \
   | tr '[:space:]' '\0' \
-  | xargs ${v:+-t} ${_o} -r -0 -P${n_jobs} -I% bash -c "
-    if command -v clone-% >/dev/null 2>&1; then
-        clone-% -j ${n_arch} --no-update-env ${OPTS[*]} || exit 255;
-    fi
-    ";
+  | xargs ${v:+-t} ${_o} -r -0 -P${n_jobs} -I% bash -c \
+  " if command -v clone-% >/dev/null 2>&1; then if ! clone-% -j ${n_arch} --no-update-env ${OPTS[*]@Q} ${v[*]@Q}; then exit 255; fi; fi";
 
     if test -z "${no_update_env-}"; then
         rapids-post-start-command;

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.clone.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.clone.tmpl.sh
@@ -36,7 +36,7 @@ clone_all() {
     echo ${NAMES} \
   | tr '[:space:]' '\0' \
   | xargs ${v:+-t} ${_o} -r -0 -P${n_jobs} -I% bash -c "
-    if type clone-% >/dev/null 2>&1; then
+    if command -v clone-% >/dev/null 2>&1; then
         clone-% -j ${n_arch} --no-update-env ${OPTS[*]} || exit 255;
     fi
     ";

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.clone.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.clone.tmpl.sh
@@ -38,7 +38,7 @@ clone_all() {
   | xargs ${v:+-t} ${_o} -r -0 -P${n_jobs} -I% bash -c \
   " if command -v clone-% >/dev/null 2>&1; then if ! clone-% -j ${n_arch} --no-update-env ${OPTS[*]@Q} ${v[*]@Q}; then exit 255; fi; fi";
 
-    if test -z "${no_update_env-}"; then
+    if ! test -n "${no_update_env:+x}"; then
         rapids-post-start-command;
     fi
 }

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.configure.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.configure.tmpl.sh
@@ -23,7 +23,7 @@ configure_all() {
     . devcontainer-utils-debug-output 'rapids_build_utils_debug' 'configure-all';
 
     for name in ${NAMES}; do
-        if type configure-${name} >/dev/null 2>&1; then
+        if command -v configure-${name} >/dev/null 2>&1; then
             configure-${name} "${OPTS[@]}";
         fi
     done

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.cpack.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.cpack.tmpl.sh
@@ -40,7 +40,7 @@ cpack_all() {
     echo ${NAMES} \
   | tr '[:space:]' '\0' \
   | xargs -r -0 -P${n_load} -I% bash -c "
-    if type cpack-% >/dev/null 2>&1; then
+    if command -v cpack-% >/dev/null 2>&1; then
         cpack-% -j ${n_arch} ${OPTS[*]} || exit 255;
     fi
     ";

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.cpack.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.cpack.tmpl.sh
@@ -25,7 +25,7 @@ cpack_all() {
     local -;
     set -euo pipefail;
 
-    eval "$(_parse_args --take '-j,--parallel' "$@" <&0)";
+    eval "$(_parse_args --take '-j,--parallel -v,--verbose' "$@" <&0)";
 
     j=${j:-1};
 
@@ -39,11 +39,8 @@ cpack_all() {
 
     echo ${NAMES} \
   | tr '[:space:]' '\0' \
-  | xargs -r -0 -P${n_load} -I% bash -c "
-    if command -v cpack-% >/dev/null 2>&1; then
-        cpack-% -j ${n_arch} ${OPTS[*]} || exit 255;
-    fi
-    ";
+  | xargs ${v:+-t} -r -0 -P${n_load} -I% bash -c \
+  " if command -v cpack-% >/dev/null 2>&1; then if ! cpack-% -j ${n_arch} ${OPTS[*]@Q} ${v[*]@Q}; then exit 255; fi; fi";
 }
 
 cpack_all "$@" <&0;

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.install.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.install.tmpl.sh
@@ -22,7 +22,7 @@ install_all() {
     . devcontainer-utils-debug-output 'rapids_build_utils_debug' 'install-all';
 
     for name in ${NAMES}; do
-        if type install-${name} >/dev/null 2>&1; then
+        if command -v install-${name} >/dev/null 2>&1; then
             install-${name} "${OPTS[@]}";
         fi
     done

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.tmpl.sh
@@ -24,7 +24,7 @@ ${SCRIPT}_all() {
     . devcontainer-utils-debug-output 'rapids_build_utils_debug' '${SCRIPT}-all';
 
     for name in ${NAMES}; do
-        if type ${SCRIPT}-${name} >/dev/null 2>&1; then
+        if command -v ${SCRIPT}-${name} >/dev/null 2>&1; then
             ${SCRIPT}-${name} "${OPTS[@]}";
         fi
     done

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.uninstall.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.uninstall.tmpl.sh
@@ -35,7 +35,7 @@ uninstall_all() {
     echo ${NAMES} \
   | tr '[:space:]' '\0' \
   | xargs ${v:+-t} -r -0 -P${n_jobs} -I% bash -c "
-    if type uninstall-% >/dev/null 2>&1; then
+    if command -v uninstall-% >/dev/null 2>&1; then
         uninstall-% ${OPTS[*]} || exit 255;
     fi
     ";

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.uninstall.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/all.uninstall.tmpl.sh
@@ -25,7 +25,7 @@ uninstall_all() {
     local -;
     set -euo pipefail;
 
-    eval "$(_parse_args --take '-h,--help -j|--parallel' "$@" <&0)";
+    eval "$(_parse_args --take '-h,--help -j,--parallel -v,--verbose' "$@" <&0)";
 
     eval "$(rapids-get-num-archs-jobs-and-load --archs 0 "$@")";
 
@@ -34,11 +34,8 @@ uninstall_all() {
 
     echo ${NAMES} \
   | tr '[:space:]' '\0' \
-  | xargs ${v:+-t} -r -0 -P${n_jobs} -I% bash -c "
-    if command -v uninstall-% >/dev/null 2>&1; then
-        uninstall-% ${OPTS[*]} || exit 255;
-    fi
-    ";
+  | xargs ${v:+-t} -r -0 -P${n_jobs} -I% bash -c \
+  " if command -v uninstall-% >/dev/null 2>&1; then if ! uninstall-% ${OPTS[*]@Q} ${v[*]@Q}; then exit 255; fi; fi";
 }
 
 uninstall_all "$@" <&0;

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/cpp.cpack.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/cpp.cpack.tmpl.sh
@@ -107,7 +107,7 @@ cpack_${CPP_LIB}_cpp() {
                 tar -C "${outd}" -c ${v:+-v} -f "${outd}/${slug}.tar.gz" -I "pigz -p ${n_jobs}" "${slug}";
                 cp -a "${outd}/${slug}.tar.gz" "${CPP_SRC}/${BIN_DIR}/";
 
-                if test -z "${out_dir-}" || test "${#out_dir[@]}" -eq 0; then
+                if ! test -n "${out_dir:+x}" || test "${#out_dir[@]}" -eq 0; then
                     continue;
                 elif test "${i}" -lt "${#out_dir[@]}"; then
                     outd="$(realpath -ms "${out_dir[$i]}")";
@@ -115,7 +115,7 @@ cpack_${CPP_LIB}_cpp() {
                     outd="$(realpath -ms "${out_dir[${#out_dir[@]}-1]}")";
                 fi
 
-                if test -n "${outd:-}"; then
+                if test -n "${outd:+x}"; then
                     mkdir -p "${outd}/";
                     cp -a "${CPP_SRC}/${BIN_DIR}/${slug}.tar.gz" "${outd}/";
                 fi

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/cpp.uninstall.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/cpp.uninstall.tmpl.sh
@@ -55,7 +55,7 @@ uninstall_${CPP_LIB}_cpp() {
 
             local outd="";
 
-            if test -z "${out_dir-}" || test "${#out_dir[@]}" -eq 0; then
+            if ! test -n "${out_dir:+x}" || test "${#out_dir[@]}" -eq 0; then
                 continue;
             elif test "${i}" -lt "${#out_dir[@]}"; then
                 outd="$(realpath -ms "${out_dir[$i]}")";
@@ -64,7 +64,7 @@ uninstall_${CPP_LIB}_cpp() {
             fi
 
             # shellcheck disable=SC2016
-            if test -n "${outd:-}"; then
+            if test -n "${outd:+x}"; then
                 local patt="cudf-.*${comp:+-$comp}-${kernel}";
                 _list_archive | grep -Ev '^.*/$' | xargs -r -d '\n' rm -f ${v:+-v} -- 2>/dev/null || true;
                 _list_archive | grep -E '^.*/$'  | xargs -r -d '\n' rmdir ${v:+-v} --ignore-fail-on-non-empty 2>/dev/null || true;

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/cpp.uninstall.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/cpp.uninstall.tmpl.sh
@@ -38,40 +38,39 @@ uninstall_${CPP_LIB}_cpp() {
 
     prefix="$(realpath -ms "${prefix:-${CONDA_PREFIX:-${CMAKE_INSTALL_PREFIX:-/usr}}}")";
 
-    time (
-        local i;
-        local -r kernel="$(uname -s)";
+    local i;
+    local -r kernel="$(uname -s)";
 
-        for ((i=0; i < ${#component[@]}; i+=1)); do
-            local comp="${component[$i]}";
-            if test "all" = "${comp}";
-                then comp="";
-            fi
+    for ((i=0; i < ${#component[@]}; i+=1)); do
+        local comp="${component[$i]}";
+        if test "all" = "${comp}";
+            then comp="";
+        fi
 
-            if test -f "${CPP_SRC}/${BIN_DIR}/install_manifest${comp:+_$comp}.txt"; then
-                xargs -rd "\n" --arg-file=<(<"${CPP_SRC}/${BIN_DIR}/install_manifest${comp:+_$comp}.txt" tr -d "\r") rm -f ${v:+-v} --;
+        local install_manifest="${CPP_SRC}/${BIN_DIR}/install_manifest${comp:+_$comp}.txt";
+
+        if test -f "$install_manifest"; then
+            xargs -r -d '\n' --arg-file=<(tr -d '\r' <"$install_manifest") rm -f ${v:+-v} -- 2>/dev/null || true;
+        else
+
+            local outd="";
+
+            if test -z "${out_dir-}" || test "${#out_dir[@]}" -eq 0; then
+                continue;
+            elif test "${i}" -lt "${#out_dir[@]}"; then
+                outd="$(realpath -ms "${out_dir[$i]}")";
             else
-
-                local outd="";
-
-                if test -z "${out_dir-}" || test "${#out_dir[@]}" -eq 0; then
-                    continue;
-                elif test "${i}" -lt "${#out_dir[@]}"; then
-                    outd="$(realpath -ms "${out_dir[$i]}")";
-                else
-                    outd="$(realpath -ms "${out_dir[${#out_dir[@]}-1]}")";
-                fi
-
-                # shellcheck disable=SC2016
-                if test -n "${outd:-}"; then
-                    local patt="cudf-.*${comp:+-$comp}-${kernel}";
-                    _list_archive | grep -Ev '^.*/$' | xargs -rd'\n' rm -f ${v:+-v} -- || true;
-                    _list_archive | grep -E '^.*/$'  | xargs -rd'\n' rmdir ${v:+-v} --ignore-fail-on-non-empty 2>/dev/null || true;
-                fi
+                outd="$(realpath -ms "${out_dir[${#out_dir[@]}-1]}")";
             fi
-        done
-        { set +x; } 2>/dev/null; echo -n "lib${CPP_LIB} uninstall time:";
-    ) 2>&1;
+
+            # shellcheck disable=SC2016
+            if test -n "${outd:-}"; then
+                local patt="cudf-.*${comp:+-$comp}-${kernel}";
+                _list_archive | grep -Ev '^.*/$' | xargs -r -d '\n' rm -f ${v:+-v} -- 2>/dev/null || true;
+                _list_archive | grep -E '^.*/$'  | xargs -r -d '\n' rmdir ${v:+-v} --ignore-fail-on-non-empty 2>/dev/null || true;
+            fi
+        fi
+    done
 }
 
 uninstall_${CPP_LIB}_cpp "$@" <&0;

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.build.wheel.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.build.wheel.tmpl.sh
@@ -54,15 +54,15 @@ build_${PY_LIB}_python_wheel() {
 
     local ninja_args=();
 
-    if test -n "${v-}"; then
+    if test -n "${v:+x}"; then
         ninja_args+=("-v");
     fi
 
-    if test -n "${n_jobs-}"; then
+    if test -n "${n_jobs:+x}"; then
         ninja_args+=("-j${n_jobs}");
     fi
 
-    if test -n "${n_load-}"; then
+    if test -n "${n_load:+x}"; then
         ninja_args+=("-l${n_load}");
     fi
 
@@ -90,7 +90,6 @@ build_${PY_LIB}_python_wheel() {
         local build_type="$(rapids-select-cmake-build-type "${cmake_args_[@]}")";
         local nvcc_append_flags="${NVCC_APPEND_FLAGS:+$NVCC_APPEND_FLAGS }-t=${n_arch}";
 
-        # SKBUILD_BUILD_TOOL_ARGS="${ninja_args[*]}"   \
         CUDAFLAGS="${cudaflags}"                     \
         CMAKE_GENERATOR="${G:-Ninja}"                \
         PARALLEL_LEVEL="${n_jobs}"                   \

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.install.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.install.tmpl.sh
@@ -52,15 +52,15 @@ install_${PY_LIB}_python() {
         $(rapids-select-cmake-args "$@")
     )";
 
-    if test -n "${v-}"; then
+    if test -n "${v:+x}"; then
         ninja_args+=("-v");
     fi
 
-    if test -n "${n_jobs-}"; then
+    if test -n "${n_jobs:+x}"; then
         ninja_args+=("-j${n_jobs}");
     fi
 
-    if test -n "${n_load-}"; then
+    if test -n "${n_load:+x}"; then
         ninja_args+=("-l${n_load}");
     fi
 
@@ -86,7 +86,7 @@ install_${PY_LIB}_python() {
         cmake_args+=("-DCMAKE_INSTALL_RPATH_USE_LINK_PATH=ON");
         local i;
         local n=1;
-        test -n "${editable:-}" && n=2;
+        test -n "${editable:+x}" && n=2;
         for ((i=0; i < ${#pip_args}; i+=1)); do
             case "${pip_args[${i}]}" in
                 -e|--editable)
@@ -108,7 +108,6 @@ install_${PY_LIB}_python() {
         local build_type="$(rapids-select-cmake-build-type "${cmake_args_[@]}")";
         local nvcc_append_flags="${NVCC_APPEND_FLAGS:+$NVCC_APPEND_FLAGS }-t=${n_arch}";
 
-        # SKBUILD_BUILD_TOOL_ARGS="${ninja_args[*]}"   \
         CUDAFLAGS="${cudaflags}"                     \
         CMAKE_GENERATOR="${G:-Ninja}"                \
         PARALLEL_LEVEL="${n_jobs}"                   \

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.uninstall.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.uninstall.tmpl.sh
@@ -25,10 +25,7 @@ uninstall_${PY_LIB}_python() {
     # shellcheck disable=SC1091
     . devcontainer-utils-debug-output 'rapids_build_utils_debug' 'uninstall-all uninstall-${NAME} uninstall-${PY_LIB}-python';
 
-    time (
-        pip uninstall --no-input -y "${v[@]}" "${q[@]}" "${PY_LIB}" || true;
-        { set +x; } 2>/dev/null; echo -n "${PY_LIB} uninstall time:";
-    ) 2>&1;
+    pip uninstall --no-input -y "${v[@]}" "${q[@]}" "${PY_LIB}" || true;
 
 }
 

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.build.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.build.tmpl.sh
@@ -27,13 +27,13 @@ build_${NAME}() {
     . devcontainer-utils-debug-output 'rapids_build_utils_debug' 'build-all build-${NAME}';
 
     for lib in ${CPP_LIB}; do
-        if type build-${lib}-cpp >/dev/null 2>&1; then
+        if command -v build-${lib}-cpp >/dev/null 2>&1; then
             build-${lib}-cpp "${OPTS[@]}";
         fi
     done
 
     for lib in ${PY_LIB}; do
-        if type build-${lib}-python >/dev/null 2>&1; then
+        if command -v build-${lib}-python >/dev/null 2>&1; then
             build-${lib}-python-${t:-${type:-"editable"}} "${OPTS[@]}";
         fi
     done

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.clean.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.clean.tmpl.sh
@@ -21,12 +21,12 @@ clean_${NAME}() {
     . devcontainer-utils-debug-output 'rapids_build_utils_debug' 'clean-all clean-${NAME}';
 
     for lib in ${CPP_LIB}; do
-        if type clean-${lib}-cpp >/dev/null 2>&1; then
+        if command -v clean-${lib}-cpp >/dev/null 2>&1; then
             clean-${lib}-cpp "${OPTS[@]}";
         fi
     done
     for lib in ${PY_LIB}; do
-        if type clean-${lib}-python >/dev/null 2>&1; then
+        if command -v clean-${lib}-python >/dev/null 2>&1; then
             clean-${lib}-python "${OPTS[@]}";
         fi
     done

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.clone.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.clone.tmpl.sh
@@ -62,13 +62,13 @@ clone_${NAME}() {
     git -C "${SRC_PATH}" config --add remote.upstream.fetch '^refs/heads/pull-request/*';
 
     local upstream_branches="$(git -C "${SRC_PATH}" branch --remotes --list 'upstream/pull-request/*')";
-    if test -n "${upstream_branches:-}"; then
+    if test -n "${upstream_branches:+x}"; then
         git -C "${SRC_PATH}" branch --remotes -d ${upstream_branches};
     fi
 
     git -C "${SRC_PATH}" remote prune upstream;
 
-    if test -z "${no_update_env-}"; then
+    if ! test -n "${no_update_env:+x}"; then
         rapids-post-start-command;
     fi
 }

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.configure.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.configure.tmpl.sh
@@ -23,7 +23,7 @@ configure_${NAME}() {
     . devcontainer-utils-debug-output 'rapids_build_utils_debug' 'configure-all configure-${NAME}';
 
     for lib in ${CPP_LIB}; do
-        if type configure-${lib}-cpp >/dev/null 2>&1; then
+        if command -v configure-${lib}-cpp >/dev/null 2>&1; then
             configure-${lib}-cpp "${OPTS[@]}";
         fi
     done

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.cpack.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.cpack.tmpl.sh
@@ -29,7 +29,7 @@ cpack_${NAME}() {
     . devcontainer-utils-debug-output 'rapids_build_utils_debug' 'cpack-all cpack-${NAME}';
 
     for lib in ${CPP_LIB}; do
-        if type cpack-${lib}-cpp >/dev/null 2>&1; then
+        if command -v cpack-${lib}-cpp >/dev/null 2>&1; then
             cpack-${lib}-cpp "${OPTS[@]}";
         fi
     done

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.install.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.install.tmpl.sh
@@ -20,7 +20,7 @@ install_${NAME}() {
     . devcontainer-utils-debug-output 'rapids_build_utils_debug' 'install-all install-${NAME}';
 
     for lib in ${CPP_LIB}; do
-        if type install-${lib}-cpp >/dev/null 2>&1; then
+        if command -v install-${lib}-cpp >/dev/null 2>&1; then
             install-${lib}-cpp "${OPTS[@]}";
         fi
     done

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.uninstall.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.uninstall.tmpl.sh
@@ -26,13 +26,13 @@ uninstall_${NAME}() {
     . devcontainer-utils-debug-output 'rapids_build_utils_debug' 'uninstall-all uninstall-${NAME}';
 
     for lib in ${CPP_LIB}; do
-        if type uninstall-${lib}-cpp >/dev/null 2>&1; then
+        if command -v uninstall-${lib}-cpp >/dev/null 2>&1; then
             uninstall-${lib}-cpp "${OPTS[@]}";
         fi
     done
 
     for lib in ${PY_LIB}; do
-        if type uninstall-${lib}-python >/dev/null 2>&1; then
+        if command -v uninstall-${lib}-python >/dev/null 2>&1; then
             uninstall-${lib}-python "${OPTS[@]}";
         fi
     done

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/update-build-dir-links.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/update-build-dir-links.sh
@@ -3,28 +3,20 @@
 # Usage:
 #  rapids-update-build-dir-links [OPTION]...
 #
-# List python package names as determined by manifest.yaml
+# Update the `build/latest` symlink for each library.
 #
 # Boolean options:
 #  -h,--help             Print this text.
+#  -v,--verbose          Verbose output.
 #
 # Options that require values:
+#  -j,--parallel <num>   Update <num> libraries in parallel
 # @_include_value_options rapids-list-repos -h | tail -n+2 | head -n-1;
 
 # shellcheck disable=SC1091
 . rapids-generate-docstring;
 
-update_build_dir_links() {
-    local -;
-    set -euo pipefail;
-
-    eval "$(_parse_args "$@" <&0)";
-
-    eval "$(rapids-list-repos "$@")";
-
-    # shellcheck disable=SC1091
-    . devcontainer-utils-debug-output 'rapids_build_utils_debug' 'update-build-dir-links';
-
+_get_library_paths() {
     local i;
     local j;
 
@@ -40,18 +32,36 @@ update_build_dir_links() {
             for ((j=0; j < ${!cpp_length:-0}; j+=1)); do
                 local cpp_sub_dir="${repo}_cpp_${j}_sub_dir";
                 local cpp_path=~/"${!repo_path:-}${!cpp_sub_dir:+/${!cpp_sub_dir}}";
-                rapids-get-cmake-build-dir --skip-build-type -- "${cpp_path}" >/dev/null;
+                echo "${cpp_path}";
             done
 
             for ((j=0; j < ${!py_length:-0}; j+=1)); do
                 local py_sub_dir="${repo}_python_${j}_sub_dir";
                 local py_path=~/"${!repo_path:-}${!py_sub_dir:+/${!py_sub_dir}}";
                 if rapids-python-uses-scikit-build-core "${py_path}"; then
-                    rapids-get-cmake-build-dir --skip-build-type -- "${py_path}" >/dev/null;
+                    echo "${py_path}";
                 fi
             done
         fi
     done
 }
 
-update_build_dir_links "$@" <&0;
+_update_build_dir_links() {
+    local -;
+    set -euo pipefail;
+
+    eval "$(_parse_args --take '-v,--verbose' "$@" <&0)";
+
+    eval "$(rapids-get-num-archs-jobs-and-load --archs 0 "$@")";
+
+    eval "$(rapids-list-repos "$@")";
+
+    # shellcheck disable=SC1091
+    . devcontainer-utils-debug-output 'rapids_build_utils_debug' 'update-build-dir-links';
+
+    _get_library_paths | tr '\n' '\0' \
+  | xargs ${v:+-t} -r -0 -n1 -P${n_jobs} bash -c \
+  " if ! rapids-get-cmake-build-dir --skip-build-type -- \"\$0\" >/dev/null; then exit 255; fi";
+}
+
+_update_build_dir_links "$@" <&0;

--- a/features/src/rust/devcontainer-feature.json
+++ b/features/src/rust/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "rust",
-  "version": "25.6.0",
+  "version": "25.6.1",
   "name": "Rust",
   "documentationURL": "https://github.com/rapidsai/devcontainers/features/tree/main/src/rust",
   "description": "Installs Rust, common Rust utilities, and their required dependencies",

--- a/features/src/rust/install.sh
+++ b/features/src/rust/install.sh
@@ -50,7 +50,7 @@ lldb_pkg="lldb";
 
 if [[ -n "${LLVM_VERSION:-}" ]]; then
     lldb_pkg="lldb-${LLVM_VERSION}";
-elif type llvm-config >/dev/null 2>&1; then
+elif command -v llvm-config >/dev/null 2>&1; then
     lldb_pkg="lldb-$(llvm-config --version | cut -d':' -f3 | cut -d'.' -f1)";
 fi
 
@@ -89,12 +89,12 @@ mkdir -p "${CARGO_HOME}" "${RUSTUP_HOME}";
 chown "${USERNAME}:rustlang" "${RUSTUP_HOME}" "${CARGO_HOME}";
 chmod g+r+w+s "${RUSTUP_HOME}" "${CARGO_HOME}";
 
-if [ "${RUST_VERSION}" = "none" ] || type rustup > /dev/null 2>&1; then
+if [ "${RUST_VERSION}" = "none" ] || command -v rustup > /dev/null 2>&1; then
     echo "Rust already installed. Skipping...";
 else
     if [ "${RUST_VERSION}" != "latest" ] && [ "${RUST_VERSION}" != "lts" ] && [ "${RUST_VERSION}" != "stable" ]; then
         # Find version using soft match
-        if ! type git >/dev/null 2>&1; then
+        if ! command -v git >/dev/null 2>&1; then
             check_packages git;
         fi
 

--- a/features/src/sccache/.bashrc
+++ b/features/src/sccache/.bashrc
@@ -1,4 +1,4 @@
-if test -z "${DISABLE_SCCACHE:+x}"; then
+if ! test -n "${DISABLE_SCCACHE:+x}"; then
     # Log sccache server messages
     export SCCACHE_SERVER_LOG="${SCCACHE_SERVER_LOG:-sccache=info}";
     export SCCACHE_ERROR_LOG="${SCCACHE_ERROR_LOG:-/tmp/sccache.log}";

--- a/features/src/sccache/devcontainer-feature.json
+++ b/features/src/sccache/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "sccache",
   "id": "sccache",
-  "version": "25.6.1",
+  "version": "25.6.2",
   "description": "A feature to install sccache",
   "options": {
     "repository": {

--- a/features/src/ucx/devcontainer-feature.json
+++ b/features/src/ucx/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "UCX",
   "id": "ucx",
-  "version": "25.6.0",
+  "version": "25.6.1",
   "description": "A feature to install UCX",
   "options": {
     "version": {

--- a/features/src/ucx/install.sh
+++ b/features/src/ucx/install.sh
@@ -32,7 +32,7 @@ download_ucx_release() {
 
     local cuda="$(read_cuda_version)";
 
-    if test -n "${cuda}"; then
+    if test -n "${cuda:+x}"; then
         slug+="-mofed5-cuda${cuda}";
     fi
 
@@ -98,7 +98,7 @@ build_and_install_ucx() {
 
 check_packages bzip2 wget ca-certificates bash-completion gettext-base pkg-config;
 
-if test -z "${UCX_VERSION:-}" || [ "${UCX_VERSION:-}" = "latest" ]; then
+if ! test -n "${UCX_VERSION:+x}" || test "${UCX_VERSION:-}" = latest; then
     find_version_from_git_tags UCX_VERSION https://github.com/openucx/ucx;
 fi
 

--- a/features/src/utils/.bashrc
+++ b/features/src/utils/.bashrc
@@ -10,31 +10,31 @@ if test -n "${PROMPT_COMMAND##*"history -a"*}"; then
 fi
 
 # Define XDG_CACHE_HOME
-if test -z "${XDG_CACHE_HOME:-}"; then
+if ! test -n "${XDG_CACHE_HOME:+x}"; then
     export XDG_CACHE_HOME="${HOME}/.cache";
 fi
 
 # Define XDG_CONFIG_HOME
-if test -z "${XDG_CONFIG_HOME:-}"; then
+if ! test -n "${XDG_CONFIG_HOME:+x}"; then
     export XDG_CONFIG_HOME="${HOME}/.config";
 fi
 
 # Define XDG_STATE_HOME
-if test -z "${XDG_STATE_HOME:-}"; then
+if ! test -n "${XDG_STATE_HOME:+x}"; then
     export XDG_STATE_HOME="${HOME}/.local/state";
 fi
 
 # Define HISTFILE
-if test -z "${HISTFILE:-}"; then
+if ! test -n "${HISTFILE:+x}"; then
     export HISTFILE="${XDG_STATE_HOME}/._bash_history";
 fi
 
 # Default python history to ~/.local/state/.python_history
-if test -z "${PYTHONHISTFILE:-}"; then
+if ! test -n "${PYTHONHISTFILE:+x}"; then
     export PYTHONHISTFILE="${XDG_STATE_HOME}/.python_history";
 fi
 
 # Default python startup file to `devcontainer-utils-python-repl-startup` script.
-if test -z "${PYTHONSTARTUP:-}"; then
+if ! test -n "${PYTHONSTARTUP:+x}"; then
     export PYTHONSTARTUP="/usr/bin/devcontainer-utils-python-repl-startup";
 fi

--- a/features/src/utils/devcontainer-feature.json
+++ b/features/src/utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "devcontainer-utils",
   "id": "utils",
-  "version": "25.6.1",
+  "version": "25.6.2",
   "description": "A feature to install RAPIDS devcontainer utility scripts",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/utils/install.sh
+++ b/features/src/utils/install.sh
@@ -21,7 +21,7 @@ PKGS=(
     ca-certificates
 );
 
-if ! type /usr/bin/python3 >/dev/null 2>&1; then
+if ! command -v /usr/bin/python3 >/dev/null 2>&1; then
     PKGS+=(python3 python3-pip);
 elif ! /usr/bin/python3 -m pip >/dev/null 2>&1; then
     PKGS+=(python3-pip);
@@ -45,7 +45,7 @@ fi
 /usr/bin/python3 -m pip install "${_PIP_INSTALL_ARGS[@]}" "${_PIP_UPGRADE_ARGS[@]}" pip;
 
 # Install yq if not installed
-if ! type yq >/dev/null 2>&1; then
+if ! command -v yq >/dev/null 2>&1; then
     YQ_BINARY="yq";
     YQ_BINARY+="_$(uname -s | tr '[:upper:]' '[:lower:]')";
     YQ_BINARY+="_${TARGETARCH:-$(dpkg --print-architecture | awk -F'-' '{print $NF}')}";
@@ -184,7 +184,7 @@ find_non_root_user;
 if test -n "${USERNAME-}"; then
     USERHOME="$(bash -c "echo ~${USERNAME-}")";
 
-    if type gh >/dev/null 2>&1; then
+    if command -v gh >/dev/null 2>&1; then
         mkdir -p -m 0755                                         \
             "$USERHOME/.local"                                   \
             "$USERHOME/.local/share"                             \
@@ -217,10 +217,10 @@ fi
 
 # Generate bash completions
 if dpkg -s bash-completion >/dev/null 2>&1; then
-    if type gh >/dev/null 2>&1; then
+    if command -v gh >/dev/null 2>&1; then
         gh completion -s bash | tee /etc/bash_completion.d/gh >/dev/null;
     fi
-    if type glab >/dev/null 2>&1; then
+    if command -v glab >/dev/null 2>&1; then
         glab completion -s bash | tee /etc/bash_completion.d/glab >/dev/null;
     fi
 fi

--- a/features/src/utils/install.sh
+++ b/features/src/utils/install.sh
@@ -181,8 +181,8 @@ rm -rf /root/.config/{clangd,pip};
 # Find the non-root user
 find_non_root_user;
 
-if test -n "${USERNAME-}"; then
-    USERHOME="$(bash -c "echo ~${USERNAME-}")";
+if test -n "${USERNAME:+x}"; then
+    USERHOME="$(bash -c "echo ~${USERNAME}")";
 
     if command -v gh >/dev/null 2>&1; then
         mkdir -p -m 0755                                         \

--- a/features/src/utils/opt/devcontainer/bin/bash/generate-bash-completion.sh
+++ b/features/src/utils/opt/devcontainer/bin/bash/generate-bash-completion.sh
@@ -33,7 +33,7 @@ generate_bash_completion() {
 
     if test -f "${template}"; then
         mkdir -p "$(dirname "${out_file}")";
-        cp -n "${template}" "${out_file}";
+        cp -u "${template}" "${out_file}";
         local cmd;
         for cmd in "${command[@]}"; do
             local str="complete -F _devcontainer_utils_completions ${cmd};";

--- a/features/src/utils/opt/devcontainer/bin/creds/s3/generate.sh
+++ b/features/src/utils/opt/devcontainer/bin/creds/s3/generate.sh
@@ -7,14 +7,14 @@ _creds_s3_generate() {
     # shellcheck disable=SC1091
     . devcontainer-utils-debug-output 'devcontainer_utils_debug' 'creds-s3 creds-s3-generate';
 
-    if test -z "${SCCACHE_BUCKET:-}"; then
+    if ! test -n "${SCCACHE_BUCKET:+x}"; then
         exit 1;
     fi
 
-    if test -n "${AWS_ROLE_ARN:-}" && gh nv-gha-aws --help >/dev/null 2>&1; then
+    if test -n "${AWS_ROLE_ARN:+x}" && gh nv-gha-aws --help >/dev/null 2>&1; then
         # shellcheck disable=SC1091
         devcontainer-utils-creds-s3-gh-generate;
-    elif test -n "${VAULT_HOST:-}"; then
+    elif test -n "${VAULT_HOST:+x}"; then
         # shellcheck disable=SC1091
         devcontainer-utils-creds-s3-vault-generate;
     fi

--- a/features/src/utils/opt/devcontainer/bin/creds/s3/gh/generate.sh
+++ b/features/src/utils/opt/devcontainer/bin/creds/s3/gh/generate.sh
@@ -7,8 +7,8 @@ _creds_github_generate() {
     # shellcheck disable=SC1091
     . devcontainer-utils-debug-output 'devcontainer_utils_debug' 'creds-s3 creds-s3-vault creds-s3-vault-generate';
 
-    if test -z "${AWS_ROLE_ARN:-}" \
-    || test -z "${SCCACHE_BUCKET:-}" \
+    if ! test -n "${AWS_ROLE_ARN:+x}" \
+    || ! test -n "${SCCACHE_BUCKET:+x}" \
     || ! gh nv-gha-aws --help >/dev/null 2>&1; then
         exit 1;
     fi

--- a/features/src/utils/opt/devcontainer/bin/creds/s3/init.sh
+++ b/features/src/utils/opt/devcontainer/bin/creds/s3/init.sh
@@ -11,7 +11,7 @@ _s3_creds_init() {
     # shellcheck disable=SC1091
     . devcontainer-utils-debug-output 'devcontainer_utils_debug' 'creds-s3 creds-s3-init';
 
-    if type sccache >/dev/null 2>&1; then
+    if command -v sccache >/dev/null 2>&1; then
         if ! grep -qE "^$" <<< "${SCCACHE_BUCKET:-}"; then
             if grep -qE "^$" <<< "${AWS_ACCESS_KEY_ID:-}"     \
             && grep -qE "^$" <<< "${AWS_SECRET_ACCESS_KEY:-}" ; then

--- a/features/src/utils/opt/devcontainer/bin/creds/s3/persist.sh
+++ b/features/src/utils/opt/devcontainer/bin/creds/s3/persist.sh
@@ -49,7 +49,7 @@ _creds_s3_persist() {
         for name in config credentials; do
             echo > ~/".aws/${name}"
         done
-        if test -n "${stamp:-}"; then
+        if test -n "${stamp:+x}"; then
             echo "${stamp:-}" > ~/.aws/stamp;
         fi
     fi

--- a/features/src/utils/opt/devcontainer/bin/creds/s3/propagate.sh
+++ b/features/src/utils/opt/devcontainer/bin/creds/s3/propagate.sh
@@ -7,7 +7,7 @@ _creds_s3_propagate() {
     # shellcheck disable=SC1091
     . devcontainer-utils-debug-output 'devcontainer_utils_debug' 'creds-s3 creds-s3-propagate';
 
-    if ! type sccache >/dev/null 2>&1; then
+    if ! command -v sccache >/dev/null 2>&1; then
         return;
     fi
 

--- a/features/src/utils/opt/devcontainer/bin/creds/s3/test.sh
+++ b/features/src/utils/opt/devcontainer/bin/creds/s3/test.sh
@@ -9,7 +9,7 @@ _creds_s3_test() {
     # shellcheck disable=SC1091
     . devcontainer-utils-debug-output 'devcontainer_utils_debug' 'creds-s3 creds-s3-test';
 
-    if ! type sccache >/dev/null 2>&1; then exit 1; fi
+    if ! command -v sccache >/dev/null 2>&1; then exit 1; fi
 
     if test -f ~/.aws/stamp; then
         local -r now="$(date '+%s')";

--- a/features/src/utils/opt/devcontainer/bin/creds/s3/vault/generate.sh
+++ b/features/src/utils/opt/devcontainer/bin/creds/s3/vault/generate.sh
@@ -9,8 +9,8 @@ _creds_vault_generate() {
     # shellcheck disable=SC1091
     . devcontainer-utils-debug-output 'devcontainer_utils_debug' 'creds-s3 creds-s3-vault creds-s3-vault-generate';
 
-    if test -z "${VAULT_HOST:-}" \
-    || test -z "${SCCACHE_BUCKET:-}"; then
+    if ! test -n "${VAULT_HOST:+x}" \
+    || ! test -n "${SCCACHE_BUCKET:+x}"; then
         exit 1;
     fi
 
@@ -30,7 +30,7 @@ _creds_vault_generate() {
     # shellcheck disable=SC1091
     . devcontainer-utils-init-github-cli;
 
-    if test -z "${GITHUB_USER:-}"; then
+    if ! test -n "${GITHUB_USER:+x}"; then
         exit 1;
     fi
 

--- a/features/src/utils/opt/devcontainer/bin/debug-output.sh
+++ b/features/src/utils/opt/devcontainer/bin/debug-output.sh
@@ -4,7 +4,7 @@
 
 for var in ${1}; do
     var="${!var:-}";
-    if test -n "${var:-}"; then
+    if test -n "${var:+x}"; then
         for str in '*' ${2}; do
             if test -z "${var##*"${str}"*}"; then
                 __xtrace=1;
@@ -18,7 +18,7 @@ done
 shift;
 unset var;
 
-if test -n "${__xtrace:-}"; then
+if test -n "${__xtrace:+x}"; then
     unset __xtrace;
     PS4="+ ${BASH_SOURCE[${#BASH_SOURCE[@]}-1]}:\${LINENO} ";
     set -x;

--- a/features/src/utils/opt/devcontainer/bin/git/init.sh
+++ b/features/src/utils/opt/devcontainer/bin/git/init.sh
@@ -10,7 +10,7 @@ init_git_cli_config() {
         fi
     fi
 
-    if test -n "${SSH_AUTH_SOCK:-}" && command -v ssh-add >/dev/null 2>&1; then
+    if test -n "${SSH_AUTH_SOCK:+x}" && command -v ssh-add >/dev/null 2>&1; then
         mkdir -p ~/.config/git;
         git config --global gpg.ssh.allowedSignersFile ~/.config/git/allowed_signers;
         awk 'BEGIN {FS=" "; OFS=" "} {print $3, $1, $2}' <(ssh-add -L) > ~/.config/git/allowed_signers;

--- a/features/src/utils/opt/devcontainer/bin/git/init.sh
+++ b/features/src/utils/opt/devcontainer/bin/git/init.sh
@@ -10,7 +10,7 @@ init_git_cli_config() {
         fi
     fi
 
-    if test -n "${SSH_AUTH_SOCK:-}" && type ssh-add >/dev/null 2>&1; then
+    if test -n "${SSH_AUTH_SOCK:-}" && command -v ssh-add >/dev/null 2>&1; then
         mkdir -p ~/.config/git;
         git config --global gpg.ssh.allowedSignersFile ~/.config/git/allowed_signers;
         awk 'BEGIN {FS=" "; OFS=" "} {print $3, $1, $2}' <(ssh-add -L) > ~/.config/git/allowed_signers;

--- a/features/src/utils/opt/devcontainer/bin/git/repo/clone.sh
+++ b/features/src/utils/opt/devcontainer/bin/git/repo/clone.sh
@@ -40,7 +40,7 @@ clone_git_repo() {
         directory="${REST[1]:?"fatal: missing required positional argument <directory>"}";
     else
         if test "${nargs}" -eq 0; then
-            if test -z "${upstream:-}"; then
+            if ! test -n "${upstream:+x}"; then
                 echo "fatal: missing required positional argument <repository>" 1>&2;
                 exit 1;
             fi
@@ -83,7 +83,7 @@ clone_git_repo() {
 
     git -C "${directory}" fetch "${fqj[@]}" --all;
 
-    if test -n "${branch:-}"; then
+    if test -n "${branch:+x}"; then
         local remote;
         for remote in upstream origin; do
             # if remote has branch

--- a/features/src/utils/opt/devcontainer/bin/github/cli/init.sh
+++ b/features/src/utils/opt/devcontainer/bin/github/cli/init.sh
@@ -4,7 +4,7 @@ init_github_cli() {
     local -;
     set -euo pipefail;
 
-    if ! type gh > /dev/null 2>&1; then
+    if ! command -v gh > /dev/null 2>&1; then
         export GITHUB_USER="";
         return;
     fi
@@ -17,7 +17,7 @@ init_github_cli() {
     else
         if grep -q "You've successfully authenticated" <<< "$(ssh -T "git@${GITHUB_HOST:-github.com}" 2>&1)"; then
             git_protocol="ssh";
-            if type ssh-keygen > /dev/null 2>&1; then
+            if command -v ssh-keygen > /dev/null 2>&1; then
                 avoid_gh_cli_ssh_keygen_prompt=1;
             fi
         fi

--- a/features/src/utils/opt/devcontainer/bin/github/repo/clone.sh
+++ b/features/src/utils/opt/devcontainer/bin/github/repo/clone.sh
@@ -73,7 +73,7 @@ ________EOF
             # Work around https://github.com/cli/cli/issues/7881 by explicitly enumerating each user fork and checking the parent info
             for repo in $(GH_HOST="${https_url}" gh repo list --limit 9999 "${user}" --fork --json name --jq 'map(.name)[]'); do
                 nameWithOwner="$(GH_HOST="${https_url}" gh repo view "${repo}" --json nameWithOwner --json parent --jq "[.] ${query}" 2>/dev/null || echo "")";
-                if test -n "${nameWithOwner}"; then
+                if test -n "${nameWithOwner:+x}"; then
                     break;
                 fi
             done
@@ -109,15 +109,15 @@ clone_github_repo() {
     ssh_url="${ssh_url:-${GITHUB_HOST:-github.com}}";
     https_url="${https_url:-${GITHUB_HOST:-github.com}}";
 
-    if test -z "${no_fork:-}" && \
-       test -z "${clone_upstream:-}" && \
+    if ! test -n "${no_fork:+x}" && \
+       ! test -n "${clone_upstream:+x}" && \
        devcontainer-utils-shell-is-interactive; then
         # shellcheck disable=SC1091
         . devcontainer-utils-init-github-cli;
         user="${GITHUB_USER:-}";
     fi
 
-    if test -n "${clone_upstream:-}"; then
+    if test -n "${clone_upstream:+x}"; then
         fork="${upstream}";
     else
         name="$(get_repo_name "${upstream}")";
@@ -127,10 +127,10 @@ clone_github_repo() {
         fork="$(get_user_fork_name "${owner}" "${name}" "${user}")";
     fi
 
-    if test -n "${fork:-}"; then
+    if test -n "${fork:+x}"; then
         origin="${fork}";
-    elif test -z "${no_fork:-}" && \
-         test -z "${clone_upstream:-}" && \
+    elif ! test -n "${no_fork:+x}" && \
+         ! test -n "${clone_upstream:+x}" && \
          devcontainer-utils-shell-is-interactive; then
         while true; do
             local CHOICE;
@@ -149,8 +149,8 @@ clone_github_repo() {
     local origin_;
     local upstream_;
 
-    if test -z "${no_fork:-}" && \
-       test -z "${clone_upstream:-}" && \
+    if ! test -n "${no_fork:+x}" && \
+       ! test -n "${clone_upstream:+x}" && \
        gh auth status --hostname "${https_url}" >/dev/null 2>&1; then
         if [ "$(gh config get git_protocol --host "${https_url}")" = "ssh" ]; then
             origin_="$(get_repo_ssh_url "${origin}")";
@@ -161,7 +161,7 @@ clone_github_repo() {
         fi
     fi
 
-    if test -z "${origin_:-}" || test -z "${upstream_:-}"; then
+    if ! test -n "${origin_:+x}" || ! test -n "${upstream_:+x}"; then
         if [ "$(gh config get git_protocol --host "${https_url}")" = "ssh" ]; then
             origin_="${origin_:-"ssh://git@${ssh_url}/${origin}.git"}";
             upstream_="${upstream_:-"ssh://git@${ssh_url}/${upstream}.git"}";

--- a/features/src/utils/opt/devcontainer/bin/gitlab/cli/init.sh
+++ b/features/src/utils/opt/devcontainer/bin/gitlab/cli/init.sh
@@ -16,7 +16,7 @@ init_gitlab_cli() {
     local -;
     set -euo pipefail;
 
-    if ! type glab > /dev/null 2>&1; then
+    if ! command -v glab > /dev/null 2>&1; then
         export GITLAB_USER="";
         return;
     fi

--- a/features/src/utils/opt/devcontainer/bin/gitlab/repo/clone.sh
+++ b/features/src/utils/opt/devcontainer/bin/gitlab/repo/clone.sh
@@ -133,15 +133,15 @@ clone_gitlab_repo() {
     ssh_url="${ssh_url:-${GITLAB_HOST:-gitlab.com}}";
     https_url="${https_url:-${GITLAB_HOST:-gitlab.com}}";
 
-    if test -z "${no_fork:-}" && \
-       test -z "${clone_upstream:-}" && \
+    if ! test -n "${no_fork:+x}" && \
+       ! test -n "${clone_upstream:+x}" && \
        devcontainer-utils-shell-is-interactive; then
         # shellcheck disable=SC1091
         . devcontainer-utils-init-gitlab-cli;
         user="${GITLAB_USER:-}";
     fi
 
-    if test -n "${clone_upstream:-}"; then
+    if test -n "${clone_upstream:+x}"; then
         fork="${upstream}";
     else
         name="$(get_repo_name "${upstream}")";
@@ -151,10 +151,10 @@ clone_gitlab_repo() {
         fork="$(get_user_fork_name "${owner}" "${name}" "${user}")";
     fi
 
-    if test -n "${fork:-}"; then
+    if test -n "${fork:+x}"; then
         origin="${fork}";
-    elif test -z "${no_fork:-}" && \
-         test -z "${clone_upstream:-}" && \
+    elif ! test -n "${no_fork:+x}" && \
+         ! test -n "${clone_upstream:+x}" && \
          devcontainer-utils-shell-is-interactive; then
         while true; do
             local CHOICE;
@@ -173,8 +173,8 @@ clone_gitlab_repo() {
     local origin_;
     local upstream_;
 
-    if test -z "${no_fork:-}" && \
-       test -z "${clone_upstream:-}" && \
+    if ! test -n "${no_fork:+x}" && \
+       ! test -n "${clone_upstream:+x}" && \
      ! glab auth status --hostname "${https_url}"  2>&1 | grep -q "No token provided"; then
         if [ "$(glab config get git_protocol --host "${https_url}")" = "ssh" ]; then
             origin_="$(get_repo_ssh_url "${origin}")";
@@ -185,7 +185,7 @@ clone_gitlab_repo() {
         fi
     fi
 
-    if test -z "${origin_:-}" || test -z "${upstream_:-}"; then
+    if ! test -n "${origin_:+x}" || ! test -n "${upstream_:+x}"; then
         if [ "$(glab config get git_protocol --host "${https_url}")" = "ssh" ]; then
             origin_="${origin_:-"ssh://git@${ssh_url}/${origin}.git"}";
             upstream_="${upstream_:-"ssh://git@${ssh_url}/${upstream}.git"}";

--- a/features/src/utils/opt/devcontainer/bin/post-attach-command.sh
+++ b/features/src/utils/opt/devcontainer/bin/post-attach-command.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-if test -z "${SKIP_DEVCONTAINER_UTILS_POST_ATTACH_COMMAND:-}"; then
+if ! test -n "${SKIP_DEVCONTAINER_UTILS_POST_ATTACH_COMMAND:+x}"; then
     # shellcheck disable=SC1091
     . devcontainer-utils-init-git-interactive;
     # shellcheck disable=SC1091

--- a/features/src/utils/opt/devcontainer/bin/post-create-command.sh
+++ b/features/src/utils/opt/devcontainer/bin/post-create-command.sh
@@ -11,7 +11,7 @@ fi
 
 # If SSH_AUTH_SOCK exists and isn't owned by the coder user, use socat to proxy
 # between a socket owned by the coder user and the one mounted in from the host
-if test -n "${SSH_AUTH_SOCK:-}" \
+if test -n "${SSH_AUTH_SOCK:+x}" \
 && test "${SSH_AUTH_SOCK}" != ~/.ssh/socket \
 && test "$(stat -c "%u:%g" "${SSH_AUTH_SOCK}")" != "$(id -u):$(id -g)"; then
     # shellcheck disable=SC1091
@@ -32,7 +32,7 @@ if test -n "${SSH_AUTH_SOCK:-}" \
 fi
 
 # Randomize the sccache server port in case the container is launched with --network=host
-if test -z "${SCCACHE_SERVER_PORT:-}"; then
+if ! test -n "${SCCACHE_SERVER_PORT:+x}"; then
     reset_envvar SCCACHE_SERVER_PORT;
     override_envvar SCCACHE_SERVER_PORT "$((4220 + $RANDOM % 4999))";
 fi

--- a/features/src/utils/opt/devcontainer/bin/post-start-command.sh
+++ b/features/src/utils/opt/devcontainer/bin/post-start-command.sh
@@ -1,6 +1,6 @@
 #! /usr/bin/env bash
 
-if test -z "${SKIP_DEVCONTAINER_UTILS_POST_START_COMMAND:-}"; then
+if ! test -n "${SKIP_DEVCONTAINER_UTILS_POST_START_COMMAND:+x}"; then
     sudo mkdir -m 0777 -p /var/log/devcontainer-utils;
     sudo touch /var/log/devcontainer-utils/creds-s3.log;
     sudo chmod 0777 /var/log/devcontainer-utils/creds-s3.log;

--- a/features/test/llvm/clang-format.sh
+++ b/features/test/llvm/clang-format.sh
@@ -20,8 +20,8 @@ check "version" bash -c "echo '$LLVM_VERSION' | grep '17'";
 check "clang-format version" bash -c "clang-format --version | grep 'clang-format version $LLVM_VERSION'";
 check "apt repo" grep "llvm-toolchain-$(lsb_release -cs)-17 main" $(find /etc/apt -type f -name '*.list');
 
-check "clang is not installed" bash -c '! type clang';
-check "clang++ is not installed" bash -c '! type clang++';
+check "clang is not installed" bash -c '! command -v clang';
+check "clang++ is not installed" bash -c '! command -v clang++';
 check "clang-format is installed" bash -c 'which clang-format';
 
 # Report result

--- a/features/test/utils/ubuntu18.04.sh
+++ b/features/test/utils/ubuntu18.04.sh
@@ -83,8 +83,8 @@ expect_local_disk_cache_is_used() {
     grep -qE 'Cache location \s+ Local disk' <<< "${stats}";
 }
 
-if test -n "${vault_host:-}" \
-&& test -n "${rw_sccache_bucket:-}"; then
+if test -n "${vault_host:+x}" \
+&& test -n "${rw_sccache_bucket:+x}"; then
 
     vault_host_with_no_bucket_uses_local_disk_cache() {
         reset_state;
@@ -96,7 +96,7 @@ if test -n "${vault_host:-}" \
     check "VAULT_HOST with no SCCACHE_BUCKET uses local disk cache" vault_host_with_no_bucket_uses_local_disk_cache;
 fi
 
-if test -n "${rw_sccache_bucket:-}"; then
+if test -n "${rw_sccache_bucket:+x}"; then
 
     no_creds_with_bucket_uses_local_disk_cache() {
         reset_state;
@@ -129,9 +129,9 @@ if test -n "${rw_sccache_bucket:-}"; then
     check "bad creds with SCCACHE_BUCKET and no VAULT_HOST uses local disk cache" bad_creds_with_sccache_bucket_and_no_vault_host_uses_local_disk_cache;
 fi
 
-if test -n "${gh_token:-}" \
-&& test -n "${vault_host:-}" \
-&& test -n "${rw_sccache_bucket:-}"; then
+if test -n "${gh_token:+x}" \
+&& test -n "${vault_host:+x}" \
+&& test -n "${rw_sccache_bucket:+x}"; then
 
     no_creds_with_GH_TOKEN_VAULT_HOST_and_SCCACHE_BUCKET_should_generate_credentials() {
         reset_state;
@@ -187,9 +187,9 @@ if test -n "${gh_token:-}" \
     check "bad stored creds with GH_TOKEN, VAULT_HOST, and SCCACHE_BUCKET should regenerate credentials" bad_stored_creds_with_GH_TOKEN_VAULT_HOST_and_SCCACHE_BUCKET_should_regenerate_credentials;
 fi
 
-if test -n "${gh_token:-}" \
-&& test -n "${aws_role_arn:-}" \
-&& test -n "${rw_sccache_bucket:-}"; then
+if test -n "${gh_token:+x}" \
+&& test -n "${aws_role_arn:+x}" \
+&& test -n "${rw_sccache_bucket:+x}"; then
 
     no_creds_with_GH_TOKEN_AWS_ROLE_ARN_and_SCCACHE_BUCKET_should_generate_credentials() {
         reset_state;

--- a/features/test/utils/ubuntu20.04.sh
+++ b/features/test/utils/ubuntu20.04.sh
@@ -83,8 +83,8 @@ expect_local_disk_cache_is_used() {
     grep -qE 'Cache location \s+ Local disk' <<< "${stats}";
 }
 
-if test -n "${vault_host:-}" \
-&& test -n "${rw_sccache_bucket:-}"; then
+if test -n "${vault_host:+x}" \
+&& test -n "${rw_sccache_bucket:+x}"; then
 
     vault_host_with_no_bucket_uses_local_disk_cache() {
         reset_state;
@@ -96,7 +96,7 @@ if test -n "${vault_host:-}" \
     check "VAULT_HOST with no SCCACHE_BUCKET uses local disk cache" vault_host_with_no_bucket_uses_local_disk_cache;
 fi
 
-if test -n "${rw_sccache_bucket:-}"; then
+if test -n "${rw_sccache_bucket:+x}"; then
 
     no_creds_with_bucket_uses_local_disk_cache() {
         reset_state;
@@ -129,9 +129,9 @@ if test -n "${rw_sccache_bucket:-}"; then
     check "bad creds with SCCACHE_BUCKET and no VAULT_HOST uses local disk cache" bad_creds_with_sccache_bucket_and_no_vault_host_uses_local_disk_cache;
 fi
 
-if test -n "${gh_token:-}" \
-&& test -n "${vault_host:-}" \
-&& test -n "${rw_sccache_bucket:-}"; then
+if test -n "${gh_token:+x}" \
+&& test -n "${vault_host:+x}" \
+&& test -n "${rw_sccache_bucket:+x}"; then
 
     no_creds_with_GH_TOKEN_VAULT_HOST_and_SCCACHE_BUCKET_should_generate_credentials() {
         reset_state;
@@ -187,9 +187,9 @@ if test -n "${gh_token:-}" \
     check "bad stored creds with GH_TOKEN, VAULT_HOST, and SCCACHE_BUCKET should regenerate credentials" bad_stored_creds_with_GH_TOKEN_VAULT_HOST_and_SCCACHE_BUCKET_should_regenerate_credentials;
 fi
 
-if test -n "${gh_token:-}" \
-&& test -n "${aws_role_arn:-}" \
-&& test -n "${rw_sccache_bucket:-}"; then
+if test -n "${gh_token:+x}" \
+&& test -n "${aws_role_arn:+x}" \
+&& test -n "${rw_sccache_bucket:+x}"; then
 
     no_creds_with_GH_TOKEN_AWS_ROLE_ARN_and_SCCACHE_BUCKET_should_generate_credentials() {
         reset_state;

--- a/features/test/utils/ubuntu22.04.sh
+++ b/features/test/utils/ubuntu22.04.sh
@@ -83,8 +83,8 @@ expect_local_disk_cache_is_used() {
     grep -qE 'Cache location \s+ Local disk' <<< "${stats}";
 }
 
-if test -n "${vault_host:-}" \
-&& test -n "${rw_sccache_bucket:-}"; then
+if test -n "${vault_host:+x}" \
+&& test -n "${rw_sccache_bucket:+x}"; then
 
     vault_host_with_no_bucket_uses_local_disk_cache() {
         reset_state;
@@ -96,7 +96,7 @@ if test -n "${vault_host:-}" \
     check "VAULT_HOST with no SCCACHE_BUCKET uses local disk cache" vault_host_with_no_bucket_uses_local_disk_cache;
 fi
 
-if test -n "${rw_sccache_bucket:-}"; then
+if test -n "${rw_sccache_bucket:+x}"; then
 
     no_creds_with_bucket_uses_local_disk_cache() {
         reset_state;
@@ -129,9 +129,9 @@ if test -n "${rw_sccache_bucket:-}"; then
     check "bad creds with SCCACHE_BUCKET and no VAULT_HOST uses local disk cache" bad_creds_with_sccache_bucket_and_no_vault_host_uses_local_disk_cache;
 fi
 
-if test -n "${gh_token:-}" \
-&& test -n "${vault_host:-}" \
-&& test -n "${rw_sccache_bucket:-}"; then
+if test -n "${gh_token:+x}" \
+&& test -n "${vault_host:+x}" \
+&& test -n "${rw_sccache_bucket:+x}"; then
 
     no_creds_with_GH_TOKEN_VAULT_HOST_and_SCCACHE_BUCKET_should_generate_credentials() {
         reset_state;
@@ -187,9 +187,9 @@ if test -n "${gh_token:-}" \
     check "bad stored creds with GH_TOKEN, VAULT_HOST, and SCCACHE_BUCKET should regenerate credentials" bad_stored_creds_with_GH_TOKEN_VAULT_HOST_and_SCCACHE_BUCKET_should_regenerate_credentials;
 fi
 
-if test -n "${gh_token:-}" \
-&& test -n "${aws_role_arn:-}" \
-&& test -n "${rw_sccache_bucket:-}"; then
+if test -n "${gh_token:+x}" \
+&& test -n "${aws_role_arn:+x}" \
+&& test -n "${rw_sccache_bucket:+x}"; then
 
     no_creds_with_GH_TOKEN_AWS_ROLE_ARN_and_SCCACHE_BUCKET_should_generate_credentials() {
         reset_state;


### PR DESCRIPTION
PR with miscellaneous shell script cleanup that doesn't feel right including in other PRs. The commit history is fairly self-explanatory.

The most intrusive one is around hiding variable values from xtrace. Doing `! test -n "${foo:+x}"` instead of `test -z "${foo:-}"` matters if `$foo` is sensitive and xtrace is enabled in an environment where the sensitive value isn't redacted, because the former prints `test -n x` and the later prints `test -z fooVal`.