### PR TITLE
Use cpp sub_dir for rmm.

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "25.6.0",
+  "version": "25.6.1",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -15,7 +15,7 @@ repos:
   git: {<<: *git_defaults, repo: rmm}
   cpp:
     - name: rmm
-      sub_dir: ""
+      sub_dir: cpp
   python:
     - name: librmm
       sub_dir: python/librmm


### PR DESCRIPTION
RMM is reorganizing some files, and putting C++ code into a `cpp/` directory like the rest of RAPIDS.

This should be merged just before https://github.com/rapidsai/rmm/pull/1883.
