### PR TITLE
Normalize ucxx branch name

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "25.6.1",
+  "version": "25.6.2",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"


### PR DESCRIPTION
This PR normalizes `ucxx` branch names. When running `rapids-checkout-same-branch`, `ucxx` is always ignored. Then, if a branch name matching `branch-YY.MM` is selected, `ucxx` will use the corresponding branch name for its matching version.
