### PR TITLE
Build shared `libpython` in pip base images

### DIFF
--- a/features/src/cccl-dev/devcontainer-feature.json
+++ b/features/src/cccl-dev/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA CCCL development utilities",
   "id": "cccl-dev",
-  "version": "25.6.1",
+  "version": "25.6.2",
   "description": "A feature to install NVIDIA CCCL development utilities",
   "options": {
     "litVersion": {

--- a/features/src/cccl-dev/install.sh
+++ b/features/src/cccl-dev/install.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env bash
-set -ex
+set -e
 
 LIT_VERSION="${LITVERSION:-latest}";
 

--- a/features/src/openmpi/devcontainer-feature.json
+++ b/features/src/openmpi/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "OpenMPI",
   "id": "openmpi",
-  "version": "25.6.1",
+  "version": "25.6.2",
   "description": "A feature to install OpenMPI with optional CUDA and UCX support",
   "options": {
     "version": {

--- a/features/src/openmpi/install.sh
+++ b/features/src/openmpi/install.sh
@@ -1,5 +1,5 @@
 #! /usr/bin/env bash
-set -ex
+set -e
 
 OPENMPI_VERSION="${VERSION:-system}";
 

--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "25.6.2",
+  "version": "25.6.3",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/install.sh
+++ b/features/src/rapids-build-utils/install.sh
@@ -113,10 +113,13 @@ yq shell-completion bash | tee /etc/bash_completion.d/yq >/dev/null;
 
 # Activate venv in /etc/bash.bashrc
 append_to_etc_bashrc "$(cat .bashrc)";
+append_to_etc_bashrc "BASE_PYTHON=$(which python3)";
 # Activate venv in ~/.bashrc
 append_to_all_bashrcs "$(cat .bashrc)";
+append_to_all_bashrcs "BASE_PYTHON=$(which python3)";
 # export envvars in /etc/profile.d
 add_etc_profile_d_script rapids-build-utils "$(cat .bashrc)";
+echo "BASE_PYTHON=$(which python3)" >> "$(which /etc/profile.d/*-rapids-build-utils.sh)";
 
 # Clean up
 # rm -rf /tmp/*;

--- a/features/src/rapids-build-utils/install.sh
+++ b/features/src/rapids-build-utils/install.sh
@@ -112,14 +112,11 @@ mkdir -p /etc/bash_completion.d/;
 yq shell-completion bash | tee /etc/bash_completion.d/yq >/dev/null;
 
 # Activate venv in /etc/bash.bashrc
-append_to_etc_bashrc "$(cat .bashrc)";
-append_to_etc_bashrc "export BASE_PYTHON=$(which python3)";
+append_to_etc_bashrc "$(cat .bashrc)\n\nexport ORIG_PYTHON=$(which python3)";
 # Activate venv in ~/.bashrc
-append_to_all_bashrcs "$(cat .bashrc)";
-append_to_all_bashrcs "export BASE_PYTHON=$(which python3)";
+append_to_all_bashrcs "$(cat .bashrc)\n\nexport ORIG_PYTHON=$(which python3)";
 # export envvars in /etc/profile.d
-add_etc_profile_d_script rapids-build-utils "$(cat .bashrc)";
-echo "export BASE_PYTHON=$(which python3)" >> "/etc/profile.d/$(($(ls -1q /etc/profile.d/*.sh | wc -l) + 19))-rapids-build-utils.sh";
+add_etc_profile_d_script rapids-build-utils "$(cat .bashrc)\n\nexport ORIG_PYTHON=$(which python3)";
 
 # Clean up
 # rm -rf /tmp/*;

--- a/features/src/rapids-build-utils/install.sh
+++ b/features/src/rapids-build-utils/install.sh
@@ -113,13 +113,13 @@ yq shell-completion bash | tee /etc/bash_completion.d/yq >/dev/null;
 
 # Activate venv in /etc/bash.bashrc
 append_to_etc_bashrc "$(cat .bashrc)";
-append_to_etc_bashrc "BASE_PYTHON=$(which python3)";
+append_to_etc_bashrc "export BASE_PYTHON=$(which python3)";
 # Activate venv in ~/.bashrc
 append_to_all_bashrcs "$(cat .bashrc)";
-append_to_all_bashrcs "BASE_PYTHON=$(which python3)";
+append_to_all_bashrcs "export BASE_PYTHON=$(which python3)";
 # export envvars in /etc/profile.d
 add_etc_profile_d_script rapids-build-utils "$(cat .bashrc)";
-echo "BASE_PYTHON=$(which python3)" >> "$(which /etc/profile.d/*-rapids-build-utils.sh)";
+echo "export BASE_PYTHON=$(which python3)" >> "/etc/profile.d/$(($(ls -1q /etc/profile.d/*.sh | wc -l) + 19))-rapids-build-utils.sh";
 
 # Clean up
 # rm -rf /tmp/*;

--- a/features/src/rapids-build-utils/install.sh
+++ b/features/src/rapids-build-utils/install.sh
@@ -9,9 +9,9 @@ cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )";
 
 PKGS=(bc jq pigz sudo wget gettext-base bash-completion ca-certificates);
 
-if ! command -v /usr/bin/python3 >/dev/null 2>&1; then
+if ! command -v python3 >/dev/null 2>&1; then
     PKGS+=(python3 python3-pip);
-elif ! /usr/bin/python3 -m pip >/dev/null 2>&1; then
+elif ! python3 -m pip >/dev/null 2>&1; then
     PKGS+=(python3-pip);
 fi
 
@@ -43,9 +43,9 @@ if [[ "${DISTRIB_RELEASE}" > "22.04" ]]; then
     fi
 fi
 
-/usr/bin/python3 -m pip install "${_PIP_INSTALL_ARGS[@]}" "${_PIP_UPGRADE_ARGS[@]}" pip;
+python3 -m pip install "${_PIP_INSTALL_ARGS[@]}" "${_PIP_UPGRADE_ARGS[@]}" pip;
 # Install RAPIDS dependency file generator, conda-merge, and toml
-/usr/bin/python3 -m pip install "${_PIP_INSTALL_ARGS[@]}" \
+python3 -m pip install "${_PIP_INSTALL_ARGS[@]}" \
     'rapids-dependency-file-generator<1.14' \
     conda-merge \
     toml;

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-dependencies.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-dependencies.sh
@@ -63,7 +63,7 @@ make_conda_dependencies() {
     local cuda_version="${CUDA_VERSION:-${CUDA_VERSION_MAJOR:-12}.${CUDA_VERSION_MINOR:-0}}";
     cuda_version="$(grep -o '^[0-9]*.[0-9]' <<< "${cuda_version}")";
 
-    local python_version="${PYTHON_VERSION:-$("${BASE_PYTHON:-python3}" --version 2>&1 | cut -d' ' -f2)}";
+    local python_version="${PYTHON_VERSION:-$("${ORIG_PYTHON:-python3}" --version 2>&1 | cut -d' ' -f2)}";
     python_version="$(cut -d'.' -f3 --complement <<< "${python_version}")";
 
     local -a _matrix_selectors=(

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-dependencies.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-dependencies.sh
@@ -63,7 +63,7 @@ make_conda_dependencies() {
     local cuda_version="${CUDA_VERSION:-${CUDA_VERSION_MAJOR:-12}.${CUDA_VERSION_MINOR:-0}}";
     cuda_version="$(grep -o '^[0-9]*.[0-9]' <<< "${cuda_version}")";
 
-    local python_version="${PYTHON_VERSION:-$(python3 --version 2>&1 | cut -d' ' -f2)}";
+    local python_version="${PYTHON_VERSION:-$("${BASE_PYTHON:-python3}" --version 2>&1 | cut -d' ' -f2)}";
     python_version="$(cut -d'.' -f3 --complement <<< "${python_version}")";
 
     local -a _matrix_selectors=(

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-pip-dependencies.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-pip-dependencies.sh
@@ -64,7 +64,7 @@ make_pip_dependencies() {
     local cuda_version="${CUDA_VERSION_MAJOR_MINOR:-}";
     local -r cuda_version_major="$(cut -d'.' -f1 <<< "${cuda_version}")";
 
-    local python_version="${PYTHON_VERSION:-$("${BASE_PYTHON:-python3}" --version 2>&1 | cut -d' ' -f2)}";
+    local python_version="${PYTHON_VERSION:-$("${ORIG_PYTHON:-python3}" --version 2>&1 | cut -d' ' -f2)}";
     python_version="$(cut -d'.' -f3 --complement <<< "${python_version}")";
 
     # Why default to cuda_suffixed=true?

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-pip-dependencies.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-pip-dependencies.sh
@@ -64,7 +64,7 @@ make_pip_dependencies() {
     local cuda_version="${CUDA_VERSION_MAJOR_MINOR:-}";
     local -r cuda_version_major="$(cut -d'.' -f1 <<< "${cuda_version}")";
 
-    local python_version="${PYTHON_VERSION:-$(python3 --version 2>&1 | cut -d' ' -f2)}";
+    local python_version="${PYTHON_VERSION:-$("${BASE_PYTHON:-python3}" --version 2>&1 | cut -d' ' -f2)}";
     python_version="$(cut -d'.' -f3 --complement <<< "${python_version}")";
 
     # Why default to cuda_suffixed=true?

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-uses-scikit-build-core.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-uses-scikit-build-core.sh
@@ -5,7 +5,7 @@ set -e;
 test -f "${1}/pyproject.toml";
 
 # where rapids-build-backend is used, its does a bit of work then forwards on to another build backend... which might be scikit-build-core
-[[ "scikit_build_core.build" == "$(python3 -c "import toml; print(toml.load('${1}/pyproject.toml')['build-system']['build-backend'])" 2>/dev/null)" ]]                 \
+[[ "scikit_build_core.build" == "$("${BASE_PYTHON:-python3}" -c "import toml; print(toml.load('${1}/pyproject.toml')['build-system']['build-backend'])" 2>/dev/null)" ]]                 \
 ||                                                                                                                                                                              \
-[[ "scikit_build_core.build" == "$(python3 -c "import toml; print(toml.load('${1}/pyproject.toml')['tool']['rapids-build-backend']['build-backend'])" 2>/dev/null)" ]] \
+[[ "scikit_build_core.build" == "$("${BASE_PYTHON:-python3}" -c "import toml; print(toml.load('${1}/pyproject.toml')['tool']['rapids-build-backend']['build-backend'])" 2>/dev/null)" ]] \
 ;

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-uses-scikit-build-core.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-uses-scikit-build-core.sh
@@ -5,7 +5,7 @@ set -e;
 test -f "${1}/pyproject.toml";
 
 # where rapids-build-backend is used, its does a bit of work then forwards on to another build backend... which might be scikit-build-core
-[[ "scikit_build_core.build" == "$("${BASE_PYTHON:-python3}" -c "import toml; print(toml.load('${1}/pyproject.toml')['build-system']['build-backend'])" 2>/dev/null)" ]]                 \
+[[ "scikit_build_core.build" == "$("${ORIG_PYTHON:-python3}" -c "import toml; print(toml.load('${1}/pyproject.toml')['build-system']['build-backend'])" 2>/dev/null)" ]]                 \
 ||                                                                                                                                                                              \
-[[ "scikit_build_core.build" == "$("${BASE_PYTHON:-python3}" -c "import toml; print(toml.load('${1}/pyproject.toml')['tool']['rapids-build-backend']['build-backend'])" 2>/dev/null)" ]] \
+[[ "scikit_build_core.build" == "$("${ORIG_PYTHON:-python3}" -c "import toml; print(toml.load('${1}/pyproject.toml')['tool']['rapids-build-backend']['build-backend'])" 2>/dev/null)" ]] \
 ;

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-uses-scikit-build-core.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-uses-scikit-build-core.sh
@@ -5,7 +5,7 @@ set -e;
 test -f "${1}/pyproject.toml";
 
 # where rapids-build-backend is used, its does a bit of work then forwards on to another build backend... which might be scikit-build-core
-[[ "scikit_build_core.build" == "$(/usr/bin/python3 -c "import toml; print(toml.load('${1}/pyproject.toml')['build-system']['build-backend'])" 2>/dev/null)" ]]                 \
+[[ "scikit_build_core.build" == "$(python3 -c "import toml; print(toml.load('${1}/pyproject.toml')['build-system']['build-backend'])" 2>/dev/null)" ]]                 \
 ||                                                                                                                                                                              \
-[[ "scikit_build_core.build" == "$(/usr/bin/python3 -c "import toml; print(toml.load('${1}/pyproject.toml')['tool']['rapids-build-backend']['build-backend'])" 2>/dev/null)" ]] \
+[[ "scikit_build_core.build" == "$(python3 -c "import toml; print(toml.load('${1}/pyproject.toml')['tool']['rapids-build-backend']['build-backend'])" 2>/dev/null)" ]] \
 ;

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-uses-scikit-build.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-uses-scikit-build.sh
@@ -3,4 +3,4 @@
 set -e;
 
 test -f "${1}/pyproject.toml";
-test "True" = "$(/usr/bin/python3 -c "import toml; print(any('scikit-build-core' not in x and 'scikit-build' in x for x in toml.load('${1}/pyproject.toml')['build-system']['requires']))" 2>/dev/null)";
+test "True" = "$(python3 -c "import toml; print(any('scikit-build-core' not in x and 'scikit-build' in x for x in toml.load('${1}/pyproject.toml')['build-system']['requires']))" 2>/dev/null)";

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-uses-scikit-build.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-uses-scikit-build.sh
@@ -3,4 +3,4 @@
 set -e;
 
 test -f "${1}/pyproject.toml";
-test "True" = "$("${BASE_PYTHON:-python3}" -c "import toml; print(any('scikit-build-core' not in x and 'scikit-build' in x for x in toml.load('${1}/pyproject.toml')['build-system']['requires']))" 2>/dev/null)";
+test "True" = "$("${ORIG_PYTHON:-python3}" -c "import toml; print(any('scikit-build-core' not in x and 'scikit-build' in x for x in toml.load('${1}/pyproject.toml')['build-system']['requires']))" 2>/dev/null)";

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-uses-scikit-build.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-uses-scikit-build.sh
@@ -3,4 +3,4 @@
 set -e;
 
 test -f "${1}/pyproject.toml";
-test "True" = "$(python3 -c "import toml; print(any('scikit-build-core' not in x and 'scikit-build' in x for x in toml.load('${1}/pyproject.toml')['build-system']['requires']))" 2>/dev/null)";
+test "True" = "$("${BASE_PYTHON:-python3}" -c "import toml; print(any('scikit-build-core' not in x and 'scikit-build' in x for x in toml.load('${1}/pyproject.toml')['build-system']['requires']))" 2>/dev/null)";

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.clean.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.clean.tmpl.sh
@@ -40,7 +40,7 @@ clean_${PY_LIB}_python() {
         fi
     done
 
-    local py_ver="${PYTHON_VERSION:-$(python3 --version 2>&1 | cut -d' ' -f2)}";
+    local py_ver="${PYTHON_VERSION:-$("${BASE_PYTHON:-python3}" --version 2>&1 | cut -d' ' -f2)}";
     py_ver="$(grep -Po '^[0-9]+\.[0-9]+' <<< "${py_ver}")";
 
     if test -d "${PY_SRC}/build"; then

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.clean.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/python.clean.tmpl.sh
@@ -40,7 +40,7 @@ clean_${PY_LIB}_python() {
         fi
     done
 
-    local py_ver="${PYTHON_VERSION:-$("${BASE_PYTHON:-python3}" --version 2>&1 | cut -d' ' -f2)}";
+    local py_ver="${PYTHON_VERSION:-$("${ORIG_PYTHON:-python3}" --version 2>&1 | cut -d' ' -f2)}";
     py_ver="$(grep -Po '^[0-9]+\.[0-9]+' <<< "${py_ver}")";
 
     if test -d "${PY_SRC}/build"; then

--- a/features/src/utils/devcontainer-feature.json
+++ b/features/src/utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "devcontainer-utils",
   "id": "utils",
-  "version": "25.6.2",
+  "version": "25.6.3",
   "description": "A feature to install RAPIDS devcontainer utility scripts",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/utils/install.sh
+++ b/features/src/utils/install.sh
@@ -21,9 +21,9 @@ PKGS=(
     ca-certificates
 );
 
-if ! command -v /usr/bin/python3 >/dev/null 2>&1; then
+if ! command -v python3 >/dev/null 2>&1; then
     PKGS+=(python3 python3-pip);
-elif ! /usr/bin/python3 -m pip >/dev/null 2>&1; then
+elif ! python3 -m pip >/dev/null 2>&1; then
     PKGS+=(python3-pip);
 fi
 
@@ -42,7 +42,7 @@ if [[ "${DISTRIB_RELEASE}" > "22.04" ]]; then
     fi
 fi
 
-/usr/bin/python3 -m pip install "${_PIP_INSTALL_ARGS[@]}" "${_PIP_UPGRADE_ARGS[@]}" pip;
+python3 -m pip install "${_PIP_INSTALL_ARGS[@]}" "${_PIP_UPGRADE_ARGS[@]}" pip;
 
 # Install yq if not installed
 if ! command -v yq >/dev/null 2>&1; then

--- a/features/src/utils/install.sh
+++ b/features/src/utils/install.sh
@@ -134,10 +134,14 @@ for_each_user_bashrc 'sed -i -re "s/^(HIST(FILE)?SIZE=).*$/\1/g" "$0"';
 
 # export envvars in bashrc files
 append_to_etc_bashrc "$(cat .bashrc)";
+append_to_etc_bashrc "BASE_PYTHON=$(which python3)";
+
 append_to_all_bashrcs "$(cat .bashrc)";
+append_to_all_bashrcs "BASE_PYTHON=$(which python3)";
 
 # export envvars in /etc/profile.d
 add_etc_profile_d_script devcontainer-utils "$(cat .bashrc)";
+echo "BASE_PYTHON=$(which python3)" >> "$(which /etc/profile.d/*-devcontainer-utils.sh)";
 
 # Add GitHub's key fingerprints to known_hosts (curl -s https://api.github.com/meta | jq -r '.ssh_keys | map("github.com \(.)") | .[]')
 # Add GitLab's key fingerprints to known_hosts (https://docs.gitlab.com/ee/user/gitlab_com/index.html#ssh-known_hosts-entries)

--- a/features/src/utils/install.sh
+++ b/features/src/utils/install.sh
@@ -134,14 +134,14 @@ for_each_user_bashrc 'sed -i -re "s/^(HIST(FILE)?SIZE=).*$/\1/g" "$0"';
 
 # export envvars in bashrc files
 append_to_etc_bashrc "$(cat .bashrc)";
-append_to_etc_bashrc "BASE_PYTHON=$(which python3)";
+append_to_etc_bashrc "export BASE_PYTHON=$(which python3)";
 
 append_to_all_bashrcs "$(cat .bashrc)";
-append_to_all_bashrcs "BASE_PYTHON=$(which python3)";
+append_to_all_bashrcs "export BASE_PYTHON=$(which python3)";
 
 # export envvars in /etc/profile.d
 add_etc_profile_d_script devcontainer-utils "$(cat .bashrc)";
-echo "BASE_PYTHON=$(which python3)" >> "$(which /etc/profile.d/*-devcontainer-utils.sh)";
+echo "export BASE_PYTHON=$(which python3)" >> "/etc/profile.d/$(($(ls -1q /etc/profile.d/*.sh | wc -l) + 19))-devcontainer-utils.sh";
 
 # Add GitHub's key fingerprints to known_hosts (curl -s https://api.github.com/meta | jq -r '.ssh_keys | map("github.com \(.)") | .[]')
 # Add GitLab's key fingerprints to known_hosts (https://docs.gitlab.com/ee/user/gitlab_com/index.html#ssh-known_hosts-entries)

--- a/features/src/utils/install.sh
+++ b/features/src/utils/install.sh
@@ -133,15 +133,12 @@ for_each_user_bashrc 'sed -i -re "s/^#(export GCC_COLORS)/\1/g" "$0"';
 for_each_user_bashrc 'sed -i -re "s/^(HIST(FILE)?SIZE=).*$/\1/g" "$0"';
 
 # export envvars in bashrc files
-append_to_etc_bashrc "$(cat .bashrc)";
-append_to_etc_bashrc "export BASE_PYTHON=$(which python3)";
+append_to_etc_bashrc "$(cat .bashrc)\n\nexport ORIG_PYTHON=$(which python3)";
 
-append_to_all_bashrcs "$(cat .bashrc)";
-append_to_all_bashrcs "export BASE_PYTHON=$(which python3)";
+append_to_all_bashrcs "$(cat .bashrc)\n\nexport ORIG_PYTHON=$(which python3)";
 
 # export envvars in /etc/profile.d
-add_etc_profile_d_script devcontainer-utils "$(cat .bashrc)";
-echo "export BASE_PYTHON=$(which python3)" >> "/etc/profile.d/$(($(ls -1q /etc/profile.d/*.sh | wc -l) + 19))-devcontainer-utils.sh";
+add_etc_profile_d_script devcontainer-utils "$(cat .bashrc)\n\nexport ORIG_PYTHON=$(which python3)";
 
 # Add GitHub's key fingerprints to known_hosts (curl -s https://api.github.com/meta | jq -r '.ssh_keys | map("github.com \(.)") | .[]')
 # Add GitLab's key fingerprints to known_hosts (https://docs.gitlab.com/ee/user/gitlab_com/index.html#ssh-known_hosts-entries)

--- a/matrix.yml
+++ b/matrix.yml
@@ -14,7 +14,6 @@ x-gcc-12: &gcc_12 { name: "gcc", version: "12" }
 x-gcc-13: &gcc_13 { name: "gcc", version: "13" }
 x-gcc-14: &gcc_14 { name: "gcc", version: "14" }
 x-gcc-env: &gcc_env { CC: "gcc", CXX: "g++", CUDAHOSTCXX: "g++" }
-x-gcc-env-rapids: &gcc_env_rapids { CC: "gcc", CXX: "g++", CUDAHOSTCXX: "g++", PYTHON_VERSION: "3.12" }
 
 x-llvm-14: &llvm_14 { name: "llvm", version: "14" }
 x-llvm-15: &llvm_15 { name: "llvm", version: "15" }
@@ -31,7 +30,6 @@ x-nvhpc-env: &nvhpc_env { CC: "nvc", CXX: "nvc++", CUDAHOSTCXX: "nvc++" }
 
 x-mambaforge: &conda { name: "mambaforge" }
 x-python: &python { name: "ghcr.io/devcontainers/features/python:1.6.2", version: "os-provided", installTools: "false", hide: true }
-x-python-rapids: &python_rapids { name: "ghcr.io/devcontainers/features/python:1.6.2", version: "3.12", installTools: "false", hide: true }
 x-ucx-rapids: &ucx_rapids { name: "ucx", version: "1.18.0" }
 x-openmpi: &openmpi { name: "openmpi" }
 
@@ -142,14 +140,14 @@ include:
 - os: "ubuntu:22.04"
   images:
   # cuda
-  - { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_prev_max], env: *gcc_env_rapids }
-  - { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_curr_min], env: *gcc_env_rapids }
-  - { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_curr_max], env: *gcc_env_rapids }
-  - { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_curr_max_rapids], env: *gcc_env_rapids }
-  - { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_prev_max, *ucx_rapids, *openmpi], env: *gcc_env_rapids }
-  - { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_curr_min, *ucx_rapids, *openmpi], env: *gcc_env_rapids }
-  - { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_curr_max, *ucx_rapids, *openmpi], env: *gcc_env_rapids }
-  - { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_curr_max_rapids, *ucx_rapids, *openmpi], env: *gcc_env_rapids }
+  - { features: [*python, *clang_format_rapids, *clangd_dev, *cuda_prev_max], env: *gcc_env }
+  - { features: [*python, *clang_format_rapids, *clangd_dev, *cuda_curr_min], env: *gcc_env }
+  - { features: [*python, *clang_format_rapids, *clangd_dev, *cuda_curr_max], env: *gcc_env }
+  - { features: [*python, *clang_format_rapids, *clangd_dev, *cuda_curr_max_rapids], env: *gcc_env }
+  - { features: [*python, *clang_format_rapids, *clangd_dev, *cuda_prev_max, *ucx_rapids, *openmpi], env: *gcc_env }
+  - { features: [*python, *clang_format_rapids, *clangd_dev, *cuda_curr_min, *ucx_rapids, *openmpi], env: *gcc_env }
+  - { features: [*python, *clang_format_rapids, *clangd_dev, *cuda_curr_max, *ucx_rapids, *openmpi], env: *gcc_env }
+  - { features: [*python, *clang_format_rapids, *clangd_dev, *cuda_curr_max_rapids, *ucx_rapids, *openmpi], env: *gcc_env }
 
   # mambaforge
   - { features: [*conda], env: { PYTHON_VERSION: "3.12" } }

--- a/matrix.yml
+++ b/matrix.yml
@@ -14,6 +14,7 @@ x-gcc-12: &gcc_12 { name: "gcc", version: "12" }
 x-gcc-13: &gcc_13 { name: "gcc", version: "13" }
 x-gcc-14: &gcc_14 { name: "gcc", version: "14" }
 x-gcc-env: &gcc_env { CC: "gcc", CXX: "g++", CUDAHOSTCXX: "g++" }
+x-gcc-env-rapids: &gcc_env_rapids { CC: "gcc", CXX: "g++", CUDAHOSTCXX: "g++", PYTHON_VERSION: "3.12" }
 
 x-llvm-14: &llvm_14 { name: "llvm", version: "14" }
 x-llvm-15: &llvm_15 { name: "llvm", version: "15" }
@@ -29,7 +30,8 @@ x-nvhpc-curr: &nvhpc_curr { name: "nvhpc", version: "25.3" }
 x-nvhpc-env: &nvhpc_env { CC: "nvc", CXX: "nvc++", CUDAHOSTCXX: "nvc++" }
 
 x-mambaforge: &conda { name: "mambaforge" }
-x-python: &python { name: "ghcr.io/devcontainers/features/python:1.6.2", version: "os-provided", installTools: "false", hide: true }
+x-python: &python { name: "ghcr.io/devcontainers/features/python:1.7.1", version: "os-provided", installTools: false, enableShared: true, optimize: true, hide: true }
+x-python-rapids: &python_rapids { name: "ghcr.io/devcontainers/features/python:1.7.1", version: "3.12", installTools: false, enableShared: true, optimize: true, hide: true }
 x-ucx-rapids: &ucx_rapids { name: "ucx", version: "1.18.0" }
 x-openmpi: &openmpi { name: "openmpi" }
 
@@ -140,14 +142,14 @@ include:
 - os: "ubuntu:22.04"
   images:
   # cuda
-  - { features: [*python, *clang_format_rapids, *clangd_dev, *cuda_prev_max], env: *gcc_env }
-  - { features: [*python, *clang_format_rapids, *clangd_dev, *cuda_curr_min], env: *gcc_env }
-  - { features: [*python, *clang_format_rapids, *clangd_dev, *cuda_curr_max], env: *gcc_env }
-  - { features: [*python, *clang_format_rapids, *clangd_dev, *cuda_curr_max_rapids], env: *gcc_env }
-  - { features: [*python, *clang_format_rapids, *clangd_dev, *cuda_prev_max, *ucx_rapids, *openmpi], env: *gcc_env }
-  - { features: [*python, *clang_format_rapids, *clangd_dev, *cuda_curr_min, *ucx_rapids, *openmpi], env: *gcc_env }
-  - { features: [*python, *clang_format_rapids, *clangd_dev, *cuda_curr_max, *ucx_rapids, *openmpi], env: *gcc_env }
-  - { features: [*python, *clang_format_rapids, *clangd_dev, *cuda_curr_max_rapids, *ucx_rapids, *openmpi], env: *gcc_env }
+  - { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_prev_max], env: *gcc_env_rapids }
+  - { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_curr_min], env: *gcc_env_rapids }
+  - { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_curr_max], env: *gcc_env_rapids }
+  - { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_curr_max_rapids], env: *gcc_env_rapids }
+  - { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_prev_max, *ucx_rapids, *openmpi], env: *gcc_env_rapids }
+  - { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_curr_min, *ucx_rapids, *openmpi], env: *gcc_env_rapids }
+  - { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_curr_max, *ucx_rapids, *openmpi], env: *gcc_env_rapids }
+  - { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_curr_max_rapids, *ucx_rapids, *openmpi], env: *gcc_env_rapids }
 
   # mambaforge
   - { features: [*conda], env: { PYTHON_VERSION: "3.12" } }


### PR DESCRIPTION
This should fix the libucxx [link error](https://github.com/rapidsai/ucxx/actions/runs/14598480223/job/40961661967#step:9:2494) that cropped up:
```
  /usr/bin/ld: /usr/local/python/3.12.10/lib/libpython3.12.a(import.o): relocation R_X86_64_TPOFF32 against hidden symbol `pkgcontext' can not be used when making a shared object
```