### PR TITLE
Drop cuGraph-DGL from Manifest

### DIFF
--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -239,9 +239,6 @@ repos:
       sub_dir: python/pylibwholegraph
       depends: [wholegraph]
       args: {install: *rapids_build_backend_args}
-    - name: cugraph-dgl
-      sub_dir: python/cugraph-dgl
-      args: {install: *rapids_build_backend_args}
     - name: cugraph_pyg
       sub_dir: python/cugraph-pyg
       args: {install: *rapids_build_backend_args}


### PR DESCRIPTION
Drops cuGraph-DGL from the manifest since we are no longer publishing it.