### PR TITLE
Update rapids-dependency-file-generator

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "25.8.2",
+  "version": "25.8.3",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/install.sh
+++ b/features/src/rapids-build-utils/install.sh
@@ -46,7 +46,7 @@ fi
 python3 -m pip install "${_PIP_INSTALL_ARGS[@]}" "${_PIP_UPGRADE_ARGS[@]}" pip;
 # Install RAPIDS dependency file generator, conda-merge, and toml
 python3 -m pip install "${_PIP_INSTALL_ARGS[@]}" \
-    'rapids-dependency-file-generator<1.14' \
+    'rapids-dependency-file-generator' \
     conda-merge \
     toml;
 


### PR DESCRIPTION
I am running into problems solving the conda environment in https://github.com/rapidsai/rapidsmpf/pull/301 because the `rapids-dependency-file-generator` is too old. This updates it.
