### PR TITLE
fix pip venv prompt in python 3.13

### DIFF
--- a/features/src/rapids-build-utils/.bashrc
+++ b/features/src/rapids-build-utils/.bashrc
@@ -12,7 +12,10 @@ if [[ "${PYTHON_PACKAGE_MANAGER:-}" == "pip" ]]; then
      && [ -z "${VIRTUAL_ENV:-}" -o "${VIRTUAL_ENV}" != ~/".local/share/venvs/${DEFAULT_VIRTUAL_ENV}" ]; then
         . ~/".local/share/venvs/${DEFAULT_VIRTUAL_ENV}/bin/activate";
     elif [ -n "${VIRTUAL_ENV_PROMPT:-}" ]; then
-        if ! echo "${PS1:-}" | grep -qF "${VIRTUAL_ENV_PROMPT}"; then
+        if ! grep -qE "(.*) " <<< "${VIRTUAL_ENV_PROMPT}" \
+        && ! grep -qF "(${VIRTUAL_ENV_PROMPT}) " <<< "${PS1:-}"; then
+            export PS1="(${VIRTUAL_ENV_PROMPT}) ${PS1:-}";
+        elif ! grep -qF "${VIRTUAL_ENV_PROMPT}" <<< "${PS1:-}"; then
             export PS1="${VIRTUAL_ENV_PROMPT}${PS1:-}";
         fi
     fi

--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "25.8.4",
+  "version": "25.8.5",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"


### PR DESCRIPTION
For some reason the pip venv prompt now doesn't include the wrapping parentheses. This PR adds them back.