### PR TITLE
Update RAPIDS containers to Ubuntu 24.04

### DIFF
--- a/.devcontainer/cuda12.9-conda/devcontainer.json
+++ b/.devcontainer/cuda12.9-conda/devcontainer.json
@@ -5,7 +5,7 @@
     "args": {
       "CUDA": "12.9",
       "PYTHON_PACKAGE_MANAGER": "conda",
-      "BASE": "rapidsai/devcontainers:25.08-cpp-mambaforge-ubuntu24.04"
+      "BASE": "rapidsai/devcontainers:25.08-cpp-mambaforge"
     }
   },
   "runArgs": [

--- a/.devcontainer/cuda12.9-conda/devcontainer.json
+++ b/.devcontainer/cuda12.9-conda/devcontainer.json
@@ -5,7 +5,7 @@
     "args": {
       "CUDA": "12.9",
       "PYTHON_PACKAGE_MANAGER": "conda",
-      "BASE": "rapidsai/devcontainers:25.08-cpp-mambaforge-ubuntu22.04"
+      "BASE": "rapidsai/devcontainers:25.08-cpp-mambaforge-ubuntu24.04"
     }
   },
   "runArgs": [

--- a/.devcontainer/cuda12.9-pip/devcontainer.json
+++ b/.devcontainer/cuda12.9-pip/devcontainer.json
@@ -5,7 +5,7 @@
     "args": {
       "CUDA": "12.9",
       "PYTHON_PACKAGE_MANAGER": "pip",
-      "BASE": "rapidsai/devcontainers:25.08-cpp-cuda12.9-ucx1.18.0-openmpi5.0.7-ubuntu24.04"
+      "BASE": "rapidsai/devcontainers:25.08-cpp-cuda12.9-ucx1.18.0-openmpi5.0.7"
     }
   },
   "runArgs": [

--- a/.devcontainer/cuda12.9-pip/devcontainer.json
+++ b/.devcontainer/cuda12.9-pip/devcontainer.json
@@ -5,7 +5,7 @@
     "args": {
       "CUDA": "12.9",
       "PYTHON_PACKAGE_MANAGER": "pip",
-      "BASE": "rapidsai/devcontainers:25.08-cpp-cuda12.9-ucx1.18.0-openmpi5.0.7-ubuntu22.04"
+      "BASE": "rapidsai/devcontainers:25.08-cpp-cuda12.9-ucx1.18.0-openmpi5.0.7-ubuntu24.04"
     }
   },
   "runArgs": [

--- a/matrix.yml
+++ b/matrix.yml
@@ -145,12 +145,12 @@ include:
   # cuda
   # Commented as RAPIDS only supports one major version (CUDA 12) right now
   #- { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_prev_max_rapids], env: *gcc_env_rapids }
-  - { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_curr_min], env: *gcc_env_rapids }
+  #- { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_curr_min], env: *gcc_env_rapids }
   - { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_curr_max], env: *gcc_env_rapids }
   - { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_curr_max_rapids], env: *gcc_env_rapids }
   # Commented as RAPIDS only supports one major version (CUDA 12) right now
   #- { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_prev_max_rapids, *ucx_rapids, *openmpi], env: *gcc_env_rapids }
-  - { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_curr_min, *ucx_rapids, *openmpi], env: *gcc_env_rapids }
+  #- { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_curr_min, *ucx_rapids, *openmpi], env: *gcc_env_rapids }
   - { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_curr_max, *ucx_rapids, *openmpi], env: *gcc_env_rapids }
   - { features: [*python_rapids, *clang_format_rapids, *clangd_dev, *cuda_curr_max_rapids, *ucx_rapids, *openmpi], env: *gcc_env_rapids }
 

--- a/matrix.yml
+++ b/matrix.yml
@@ -140,7 +140,7 @@ include:
 
 # RAPIDS devcontainers
 
-- os: "ubuntu:22.04"
+- os: "ubuntu:24.04"
   images:
   # cuda
   # Commented as RAPIDS only supports one major version (CUDA 12) right now


### PR DESCRIPTION
Currently nightly builds fail for cuDF because of the use of `<format>`. This requires GCC 13 or newer.

The devcontainers are getting the OS default version of GCC (because RAPIDS devcontainers don't specify a version). The OS is Ubuntu 22.04 which ships with GCC 11. Updating to Ubuntu 24.04 should solve this problem. Alternatively we can pin the GCC version, but I like being able to use system-default toolchains where possible.
