### PR TITLE
Exclude xgboost packages

### DIFF
--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-dependencies.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-conda-dependencies.sh
@@ -161,8 +161,10 @@ make_conda_dependencies() {
             done
         done
 
+        local xgboost_packages=(xgboost py-xgboost libxgboost);
+
         # shellcheck disable=SC2207
-        local conda_noinstall=($(rapids-python-pkg-names) $(rapids-python-conda-pkg-names));
+        local conda_noinstall=($(rapids-python-pkg-names) $(rapids-python-conda-pkg-names) ${xgboost_packages[@]});
 
         # Generate a combined conda env yaml file.
         conda-merge "${conda_env_yamls[@]}"                                                                                   \


### PR DESCRIPTION
Packages for `xgboost` depend on `librmm`. However, we don't want `librmm` to be pulled in as a conda dependency. One approach to fixing this is in https://github.com/rapidsai/cuml/pull/7006 but this might be a cleaner / more minimal solution.
