### PR TITLE
Support repository dependency_keys in manifest.yaml

### DIFF
--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-pip-dependencies.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-pip-dependencies.sh
@@ -45,7 +45,6 @@ make_pip_dependencies() {
 
     test ${#exclude[@]} -eq 0 && exclude=();
     test ${#include[@]} -eq 0 && include=();
-    test ${#key[@]} -eq 0 && key=(py_build py_run py_test all);
     test ${#matrix_entry[@]} -eq 0 && matrix_entry=();
     test ${#requirement[@]} -eq 0 && requirement=();
 
@@ -95,29 +94,49 @@ make_pip_dependencies() {
     eval "$(rapids-list-repos "${OPTS[@]}")";
 
     local i;
+    local j;
 
     for ((i=0; i < ${repos_length:-0}; i+=1)); do
 
         local repo="repos_${i}";
         local repo_name="${repo}_name";
         local repo_path="${repo}_path";
+        local name="${!repo_name:-}";
+        local path="${!repo_path:-}";
 
-        if [ -f ~/"${!repo_path}/dependencies.yaml" ]; then
+        if test -n "${name:+x}" \
+        && test -n "${path:+x}" \
+        && test -f ~/"${path}/dependencies.yaml"; then
 
-            echo "Generating ${!repo_name}'s repo requirements.txt" 1>&2;
+            echo "Generating ${name}'s repo requirements.txt" 1>&2;
 
-            local repo_keys=("${key[@]}");
+            local dependency_keys=("${key[@]}");
+
+            local repo_dependency_keys_length="${repo}_dependency_keys_length";
+            for ((j=0; j < ${!repo_dependency_keys_length:-0}; j+=1)); do
+                local dependency_key="${repo}_dependency_keys_${j}";
+                dependency_key="${!dependency_key:-}";
+                if test -n "${dependency_key:+x}"; then
+                    dependency_keys+=("${dependency_key}");
+                fi
+            done
+
+            if test ${#dependency_keys[@]} -eq 0; then
+                dependency_keys=(py_build py_run py_test all);
+            fi
+
+            local keys=("${dependency_keys[@]}");
             local keyi;
 
-            for ((keyi=0; keyi < ${#repo_keys[@]}; keyi+=1)); do
-                local file="/tmp/${!repo_name}.${repo_keys[$keyi]}.requirements.txt";
+            for ((keyi=0; keyi < ${#keys[@]}; keyi+=1)); do
+                local file="/tmp/${name}.${keys[$keyi]}.requirements.txt";
                 pip_reqs_txts+=("${file}");
-                generate_requirements                            \
-                    "${file}"                                    \
-                    --file-key "${repo_keys[$keyi]}"             \
-                    --output requirements                        \
-                    --config ~/"${!repo_path}/dependencies.yaml" \
-                    --matrix "${matrix_selectors}"               \
+                generate_requirements                      \
+                    "${file}"                              \
+                    --file-key "${keys[$keyi]}"            \
+                    --output requirements                  \
+                    --config ~/"${path}/dependencies.yaml" \
+                    --matrix "${matrix_selectors}"         \
                     ;
             done
 
@@ -125,21 +144,22 @@ make_pip_dependencies() {
 
             for ((j=0; j < ${!cpp_length:-0}; j+=1)); do
                 local cpp_name="${repo}_cpp_${j}_name";
+                local cpp_name="lib${!cpp_name}";
 
-                echo "Generating lib${!cpp_name}'s requirements.txt" 1>&2;
+                echo "Generating ${cpp_name}'s requirements.txt" 1>&2;
 
-                local repo_keys=("${key[@]/%/_lib${!cpp_name//"-"/"_"}}");
+                local keys=("${dependency_keys[@]/%/_${cpp_name//"-"/"_"}}");
                 local keyi;
 
-                for ((keyi=0; keyi < ${#repo_keys[@]}; keyi+=1)); do
-                    local file="/tmp/${!repo_name}.lib${!cpp_name}.${repo_keys[$keyi]}.requirements.txt";
+                for ((keyi=0; keyi < ${#keys[@]}; keyi+=1)); do
+                    local file="/tmp/${name}.${cpp_name}.${keys[$keyi]}.requirements.txt";
                     pip_reqs_txts+=("${file}");
-                    generate_requirements                             \
-                        "${file}"                                     \
-                        --file-key "${repo_keys[$keyi]}"              \
-                        --output requirements                         \
-                        --config ~/"${!repo_path}/dependencies.yaml"  \
-                        --matrix "${matrix_selectors}"                \
+                    generate_requirements                      \
+                        "${file}"                              \
+                        --file-key "${keys[$keyi]}"            \
+                        --output requirements                  \
+                        --config ~/"${path}/dependencies.yaml" \
+                        --matrix "${matrix_selectors}"         \
                         ;
                 done
             done
@@ -148,21 +168,22 @@ make_pip_dependencies() {
 
             for ((j=0; j < ${!py_length:-0}; j+=1)); do
                 local py_name="${repo}_python_${j}_name";
+                local py_name="${!py_name}";
 
-                echo "Generating ${!py_name}'s requirements.txt" 1>&2;
+                echo "Generating ${py_name}'s requirements.txt" 1>&2;
 
-                local repo_keys=("${key[@]/%/_${!py_name//"-"/"_"}}");
+                local keys=("${dependency_keys[@]/%/_${py_name//"-"/"_"}}");
                 local keyi;
 
-                for ((keyi=0; keyi < ${#repo_keys[@]}; keyi+=1)); do
-                    local file="/tmp/${!repo_name}.${!py_name}.${repo_keys[$keyi]}.requirements.txt";
+                for ((keyi=0; keyi < ${#keys[@]}; keyi+=1)); do
+                    local file="/tmp/${name}.${py_name}.${keys[$keyi]}.requirements.txt";
                     pip_reqs_txts+=("${file}");
-                    generate_requirements                            \
-                        "${file}"                                    \
-                        --file-key "${repo_keys[$keyi]}"             \
-                        --output requirements                        \
-                        --config ~/"${!repo_path}/dependencies.yaml" \
-                        --matrix "${matrix_selectors}"               \
+                    generate_requirements                      \
+                        "${file}"                              \
+                        --file-key "${keys[$keyi]}"            \
+                        --output requirements                  \
+                        --config ~/"${path}/dependencies.yaml" \
+                        --matrix "${matrix_selectors}"         \
                         ;
                 done
             done

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -177,6 +177,12 @@ repos:
 - name: cuml
   path: cuml
   git: {<<: *git_defaults, repo: cuml}
+  dependency_keys:
+    - cpp_all
+    - docs
+    - py_build
+    - py_rapids_build
+    - py_run
   cpp:
     - name: cuml
       sub_dir: cpp


### PR DESCRIPTION
This PR isolates a change from @trxcllnt in #479 so that we can unblock CI on this repository.

We need this so we can exclude `xgboost` from cuML's dependency list, since `libxgboost` brings in `librmm` conda packages, and that breaks devcontainers building everything from source.

Closes #535.

This temporarily breaks cuML devcontainers because it does not include the cuML test dependencies, but it unblocks cuML CI.

Planned follow-up actions:
- Create a cuML dependency file key called `devcontainers` with everything except `xgboost`
- Update the `manifest.yaml` to use that file key instead of the current set of keys (if the cuML PR merges first, we can modify this PR instead of needing a follow-up)
