### PR TITLE
Add `cu++filt` package to windows devcontainer

### DIFF
--- a/windows/image/installers/install-cuda.ps1
+++ b/windows/image/installers/install-cuda.ps1
@@ -36,7 +36,8 @@ $cudaComponents =
     "nvrtc_$mmVersionTag",
     "nvrtc_dev_$mmVersionTag",
     "nvml_dev_$mmVersionTag",
-    "nvtx_$mmVersionTag"
+    "nvtx_$mmVersionTag",
+    "cuxxfilt_$mmVersionTag"
 
 Invoke-WebRequest -Uri "$cudaVersionUrl" -OutFile "./cuda_network.exe" -UseBasicParsing
 Start-Process -Wait -PassThru -FilePath .\cuda_network.exe -ArgumentList "-s $cudaComponents"


### PR DESCRIPTION
In #530 I forgot to update the windows devcontainer, too. This PR adds the `cuxxfilt` package to windows devcontainer. The package is only couple of kBs