### PR TITLE
Use devcontainers file key for cuml

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "25.8.7",
+  "version": "25.8.8",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -178,11 +178,7 @@ repos:
   path: cuml
   git: {<<: *git_defaults, repo: cuml}
   dependency_keys:
-    - cpp_all
-    - docs
-    - py_build
-    - py_rapids_build
-    - py_run
+    - devcontainers
   cpp:
     - name: cuml
       sub_dir: cpp


### PR DESCRIPTION
Follow-up to https://github.com/rapidsai/devcontainers/pull/536 now that https://github.com/rapidsai/cuml/pull/7006 is merged.
