### PR TITLE
use new cumlprims_mg repo

### DIFF
--- a/.github/workflows/build-all-rapids-repos.yml
+++ b/.github/workflows/build-all-rapids-repos.yml
@@ -38,7 +38,6 @@ jobs:
       arch: '["amd64", "arm64"]'
       cuda: '["12.9"]'
       node_type: cpu8
-      extra-repo-deploy-key: CUMLPRIMS_SSH_PRIVATE_DEPLOY_KEY
       rapids-aux-secret-1: GIST_REPO_READ_ORG_GITHUB_TOKEN
       timeout-minutes: 720
       # 1. Infinitely retry transient errors


### PR DESCRIPTION
Complements https://github.com/rapidsai/cuml/pull/7213

https://github.com/rapidsai/cumlprims_mg is now public, so we don't need to provide a deploy key for cloning it any more 😁 