### PR TITLE
Also update libmamba solver when updating conda

### DIFF
--- a/features/src/mambaforge/devcontainer-feature.json
+++ b/features/src/mambaforge/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Mambaforge",
   "id": "mambaforge",
-  "version": "25.12.0",
+  "version": "25.12.1",
   "description": "A feature to install mambaforge",
   "options": {
     "version": {

--- a/features/src/mambaforge/install.sh
+++ b/features/src/mambaforge/install.sh
@@ -28,7 +28,7 @@ rm -rf /opt/conda;
 
 export PATH="/opt/conda/bin:${PATH}";
 
-conda update -n base -c conda-forge conda;
+conda update -n base -c conda-forge conda conda-libmamba-solver;
 conda clean --tarballs --index-cache --packages --yes;
 find /opt/conda -follow -type f -name '*.a' -delete;
 find /opt/conda -follow -type f -name '*.pyc' -delete;


### PR DESCRIPTION
The current builds have mismatched versions of conda and conda-libmamba-solver. https://github.com/conda/conda/pull/15221 removed code from conda, and those changes [were just released](https://github.com/conda/conda/releases/tag/25.9.0). conda-libmamba-solver was updated in https://github.com/conda/conda-libmamba-solver/pull/641 to accommodate that, but since we currently update conda without updating conda-libmamba-solver we wind up with a version of conda missing code that the solver still needs. Updating both should resolve that.