### PR TITLE
Add pyenv-win to Windows devcontainer.

### DIFF
--- a/windows/image/install-tools.ps1
+++ b/windows/image/install-tools.ps1
@@ -23,6 +23,7 @@ Push-location "$PSScriptRoot"
 ./installers/install-sccache.ps1
 ./installers/install-tbb.ps1
 ./installers/install-docker.ps1
+./installers/install-pyenv-win.ps1
 
 ./installers/clear-temp.ps1
 

--- a/windows/image/installers/install-pyenv-win.ps1
+++ b/windows/image/installers/install-pyenv-win.ps1
@@ -1,0 +1,22 @@
+$ProgressPreference = 'SilentlyContinue'
+$ErrorActionPreference = 'Stop'
+
+# Install pyenv-win using the official installer script
+Invoke-WebRequest -UseBasicParsing -Uri `
+    "https://raw.githubusercontent.com/pyenv-win/pyenv-win/master/pyenv-win/install-pyenv-win.ps1" `
+    -OutFile "./install-pyenv-win.ps1"
+
+& "./install-pyenv-win.ps1"
+
+. "$PSScriptRoot/envvars.ps1"
+
+# Ensure PATH includes pyenv shims and bin for machine scope so pyenv is available
+Set-MachineEnvironmentVariable -Append `
+    -Variable "PATH" `
+    -Value "$env:USERPROFILE\\.pyenv\\pyenv-win\\bin"
+
+Set-MachineEnvironmentVariable -Append `
+    -Variable "PATH" `
+    -Value "$env:USERPROFILE\\.pyenv\\pyenv-win\\shims"
+
+


### PR DESCRIPTION
This allows containers to install alternate versions of Python if needed at runtime.