### PR TITLE
Support checking out all repos to main

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "25.12.2",
+  "version": "25.12.3",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/checkout-same-branch.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/checkout-same-branch.sh
@@ -85,7 +85,7 @@ checkout_same_branch() {
         echo \"local repo_branches_\${name}_='\$(                                                     \
             cat <(git -C ~/\${path} ls-remote -h origin | cut -f2 | sed \"s@refs/heads@origin@\")     \
                 <(git -C ~/\${path} ls-remote -h upstream | cut -f2 | sed \"s@refs/heads@upstream@\") \
-          | grep -Pv \"(/pull-request/|master|main)\" | tr '[:space:]' ' '                            \
+          | grep -Pv \"(/pull-request/|master)\" | tr '[:space:]' ' '                                 \
         )'\"                                                                                          \
         " %
     )";


### PR DESCRIPTION
Now that the branch migration is done, `rapids-checkout-same-repo` should support checking out the `main` branch.