### PR TITLE
Enable 256 color support

### DIFF
--- a/image/.devcontainer/devcontainer.json
+++ b/image/.devcontainer/devcontainer.json
@@ -10,7 +10,8 @@
   "containerUser": "root",
   "containerEnv": {
     "LANG": "${localEnv:LANG:en_US.UTF-8}",
-    "NVIDIA_DISABLE_REQUIRE": "true"
+    "NVIDIA_DISABLE_REQUIRE": "true",
+    "TERM": "${localEnv:TERM:xterm}"
   },
   "workspaceFolder": "/home/coder",
   "features": {


### PR DESCRIPTION
Currently `echo $TERM` gives `xterm`. I would like richer color support to make it easier to read rich outputs from AI agents in the shell. I was able to get `export TERM=xterm-256color` to help with this.
