### PR TITLE
Add CUDA 13.1 support

### DIFF
--- a/.devcontainer/cuda13.1-conda/devcontainer.json
+++ b/.devcontainer/cuda13.1-conda/devcontainer.json
@@ -1,0 +1,110 @@
+{
+  "build": {
+    "context": "${localWorkspaceFolder}/.devcontainer",
+    "dockerfile": "${localWorkspaceFolder}/.devcontainer/rapids.Dockerfile",
+    "args": {
+      "CUDA": "13.1",
+      "PYTHON_PACKAGE_MANAGER": "conda",
+      "BASE": "rapidsai/devcontainers:26.02-cpp-mambaforge"
+    }
+  },
+  "runArgs": [
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-rapids-${localWorkspaceFolderBasename}-26.02-cuda13.1-conda",
+    "--ulimit",
+    "nofile=500000"
+  ],
+  "hostRequirements": {"gpu": "optional"},
+  "features": {
+    "./features/src/cuda": {
+      "version": "13.1",
+      "installCompilers": false,
+      "installProfilers": true,
+      "installCTKLibraries": false,
+      "installDevPackages": false,
+      "installcuDNN": false,
+      "installcuTensor": false,
+      "installNCCL": false,
+      "installCUDARuntime": false,
+      "installNVRTC": false,
+      "installOpenCL": false,
+      "installcuBLAS": false,
+      "installcuSPARSE": false,
+      "installcuFFT": false,
+      "installcuFile": false,
+      "installcuRAND": false,
+      "installcuSOLVER": false,
+      "installNPP": false,
+      "installnvJPEG": false,
+      "pruneStaticLibs": true
+    },
+    "./features/src/utils": {},
+    "./features/src/rapids-build-utils": {}
+  },
+  "overrideFeatureInstallOrder": [
+    "./features/src/cuda",
+    "./features/src/utils",
+    "./features/src/rapids-build-utils"
+  ],
+  "initializeCommand": ["/bin/bash", "-c", "mkdir -m 0755 -p ${localWorkspaceFolder}/../.{aws,cache,config,conda/pkgs,conda/${localWorkspaceFolderBasename}-cuda13.1-envs,log/devcontainer-utils} ${localWorkspaceFolder}/../{rmm,dask-cuda,kvikio,ucxx,cudf,rapidsmpf,raft,cuvs,cumlprims_mg,cuml,cugraph,cugraph-gnn,nx-cugraph}"],
+  "postAttachCommand": ["/bin/bash", "-c", "if [ ${CODESPACES:-false} = 'true' ]; then . devcontainer-utils-post-attach-command; fi"],
+  "workspaceFolder": "/home/coder",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/devcontainers,type=bind,consistency=consistent",
+  "mounts": [
+    "source=/etc/timezone,target=/etc/timezone,type=bind,consistency=consistent",
+    "source=/etc/localtime,target=/etc/localtime,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../rmm,target=/home/coder/rmm,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../dask-cuda,target=/home/coder/dask-cuda,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../kvikio,target=/home/coder/kvikio,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../ucxx,target=/home/coder/ucxx,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../cudf,target=/home/coder/cudf,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../rapidsmpf,target=/home/coder/rapidsmpf,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../raft,target=/home/coder/raft,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../cuvs,target=/home/coder/cuvs,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../cumlprims_mg,target=/home/coder/cumlprims_mg,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../cuml,target=/home/coder/cuml,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../cugraph,target=/home/coder/cugraph,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../cugraph-gnn,target=/home/coder/cugraph-gnn,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../nx-cugraph,target=/home/coder/nx-cugraph,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../.config,target=/home/coder/.config,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../.conda/pkgs,target=/home/coder/.conda/pkgs,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../.conda/${localWorkspaceFolderBasename}-cuda13.1-envs,target=/home/coder/.conda/envs,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../.log/devcontainer-utils,target=/var/log/devcontainer-utils,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/.devcontainer/cuda13.1-conda/features/src/utils/opt/devcontainer/bin,target=/opt/devcontainer/bin,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/.devcontainer/cuda13.1-conda/features/src/rapids-build-utils/opt/rapids-build-utils,target=/opt/rapids-build-utils,type=bind,consistency=consistent"
+  ],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "augustocdias.tasks-shell-input",
+        "ms-python.flake8",
+        "nvidia.nsight-vscode-edition"
+      ],
+      "settings": {
+        "files.watcherExclude": {
+          "**/build/**": true,
+          "**/_skbuild/**": true,
+          "**/target/**": true,
+          "/home/coder/.aws/**/*": true,
+          "/home/coder/.cache/**/*": true,
+          "/home/coder/.conda/**/*": true,
+          "/home/coder/.local/share/**/*": true,
+          "/home/coder/.vscode-server/**/*": true
+        },
+        "search.exclude": {
+          "**/build/**": true,
+          "**/_skbuild/**": true,
+          "**/*.code-search": true,
+          "/home/coder/.aws/**/*": true,
+          "/home/coder/.cache/**/*": true,
+          "/home/coder/.conda/**/*": true,
+          "/home/coder/.local/share/**/*": true,
+          "/home/coder/.vscode-server/**/*": true
+        }
+      }
+    }
+  }
+}

--- a/.devcontainer/cuda13.1-pip/devcontainer.json
+++ b/.devcontainer/cuda13.1-pip/devcontainer.json
@@ -1,0 +1,97 @@
+{
+  "build": {
+    "context": "${localWorkspaceFolder}/.devcontainer",
+    "dockerfile": "${localWorkspaceFolder}/.devcontainer/rapids.Dockerfile",
+    "args": {
+      "CUDA": "13.1",
+      "PYTHON_PACKAGE_MANAGER": "pip",
+      "BASE": "rapidsai/devcontainers:26.02-cpp-cuda13.1-ucx1.19.0-openmpi5.0.7"
+    }
+  },
+  "runArgs": [
+    "--rm",
+    "--name",
+    "${localEnv:USER:anon}-rapids-${localWorkspaceFolderBasename}-26.02-cuda13.1-pip",
+    "--ulimit",
+    "nofile=500000"
+  ],
+  "hostRequirements": {"gpu": "optional"},
+  "features": {
+    "./features/src/cuda": {
+      "version": "13.1",
+      "cuDNNVersion": "9",
+      "installcuBLAS": true,
+      "installcuDNN": true,
+      "installcuSOLVER": true,
+      "installcuRAND": true,
+      "installcuSPARSE": true,
+      "installProfilers": true
+    },
+    "./features/src/utils": {},
+    "./features/src/rapids-build-utils": {}
+  },
+  "overrideFeatureInstallOrder": [
+    "./features/src/cuda",
+    "./features/src/utils",
+    "./features/src/rapids-build-utils"
+  ],
+  "initializeCommand": ["/bin/bash", "-c", "mkdir -m 0755 -p ${localWorkspaceFolder}/../.{aws,cache,config/pip,local/share/${localWorkspaceFolderBasename}-cuda13.1-venvs,log/devcontainer-utils} ${localWorkspaceFolder}/../{rmm,dask-cuda,kvikio,ucxx,cudf,rapidsmpf,raft,cuvs,cumlprims_mg,cuml,cugraph,cugraph-gnn,nx-cugraph}"],
+  "postAttachCommand": ["/bin/bash", "-c", "if [ ${CODESPACES:-false} = 'true' ]; then . devcontainer-utils-post-attach-command; fi"],
+  "workspaceFolder": "/home/coder",
+  "workspaceMount": "source=${localWorkspaceFolder},target=/home/coder/devcontainers,type=bind,consistency=consistent",
+  "mounts": [
+    "source=/etc/timezone,target=/etc/timezone,type=bind,consistency=consistent",
+    "source=/etc/localtime,target=/etc/localtime,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../rmm,target=/home/coder/rmm,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../dask-cuda,target=/home/coder/dask-cuda,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../kvikio,target=/home/coder/kvikio,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../ucxx,target=/home/coder/ucxx,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../cudf,target=/home/coder/cudf,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../raft,target=/home/coder/raft,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../rapidsmpf,target=/home/coder/rapidsmpf,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../cuvs,target=/home/coder/cuvs,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../cumlprims_mg,target=/home/coder/cumlprims_mg,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../cuml,target=/home/coder/cuml,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../cugraph,target=/home/coder/cugraph,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../cugraph-gnn,target=/home/coder/cugraph-gnn,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../nx-cugraph,target=/home/coder/nx-cugraph,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../.aws,target=/home/coder/.aws,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../.cache,target=/home/coder/.cache,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../.config,target=/home/coder/.config,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../.local/share/${localWorkspaceFolderBasename}-cuda13.1-venvs,target=/home/coder/.local/share/venvs,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/../.log/devcontainer-utils,target=/var/log/devcontainer-utils,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/.devcontainer/cuda13.1-pip/features/src/utils/opt/devcontainer/bin,target=/opt/devcontainer/bin,type=bind,consistency=consistent",
+    "source=${localWorkspaceFolder}/.devcontainer/cuda13.1-pip/features/src/rapids-build-utils/opt/rapids-build-utils,target=/opt/rapids-build-utils,type=bind,consistency=consistent"
+  ],
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "augustocdias.tasks-shell-input",
+        "ms-python.flake8",
+        "nvidia.nsight-vscode-edition"
+      ],
+      "settings": {
+        "files.watcherExclude": {
+          "**/build/**": true,
+          "**/_skbuild/**": true,
+          "**/target/**": true,
+          "/home/coder/.aws/**/*": true,
+          "/home/coder/.cache/**/*": true,
+          "/home/coder/.conda/**/*": true,
+          "/home/coder/.local/share/**/*": true,
+          "/home/coder/.vscode-server/**/*": true
+        },
+        "search.exclude": {
+          "**/build/**": true,
+          "**/_skbuild/**": true,
+          "**/*.code-search": true,
+          "/home/coder/.aws/**/*": true,
+          "/home/coder/.cache/**/*": true,
+          "/home/coder/.conda/**/*": true,
+          "/home/coder/.local/share/**/*": true,
+          "/home/coder/.vscode-server/**/*": true
+        }
+      }
+    }
+  }
+}

--- a/.github/workflows/build-all-rapids-repos.yml
+++ b/.github/workflows/build-all-rapids-repos.yml
@@ -36,7 +36,7 @@ jobs:
       pull-requests: read
     with:
       arch: '["amd64", "arm64"]'
-      cuda: '["12.9", "13.0"]'
+      cuda: '["12.9", "13.1"]'
       node_type: cpu16
       rapids-aux-secret-1: GIST_REPO_READ_ORG_GITHUB_TOKEN
       timeout-minutes: 720

--- a/matrix.yml
+++ b/matrix.yml
@@ -3,7 +3,7 @@ x-cuda-prev-max: &cuda_prev_max { name: "cuda", version: "12.9" }
 x-cuda-curr-min: &cuda_curr_min { name: "cuda", version: "13.0" }
 x-cuda-curr-max: &cuda_curr_max { name: "cuda", version: "13.1" }
 x-cuda-prev-max-rapids: &cuda_prev_max_rapids { name: "cuda", version: "12.9" }
-x-cuda-curr-max-rapids: &cuda_curr_max_rapids { name: "cuda", version: "13.0" }
+x-cuda-curr-max-rapids: &cuda_curr_max_rapids { name: "cuda", version: "13.1" }
 
 # CUDA 12.0 support stops at gcc 12.
 x-gcc-7: &gcc_7 { name: "gcc", version: "7" }


### PR DESCRIPTION
## Summary
- Update `cuda_curr_max_rapids` to CUDA 13.1 in matrix.yml
- Add cuda13.1-conda and cuda13.1-pip devcontainer configurations
- Update build-all-rapids-repos.yml to use CUDA 13.1

Part of https://github.com/rapidsai/build-planning/issues/236