### PR TITLE
Add messages to identify which configure/clean/cpack/install/uninstall operations are happening

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "26.2.5",
+  "version": "26.2.6",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.clean.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.clean.tmpl.sh
@@ -22,11 +22,13 @@ clean_${NAME}() {
 
     for lib in ${CPP_LIB}; do
         if command -V clean-${lib}-cpp >/dev/null 2>&1; then
+            echo -e "\033[1;36mCleaning ${lib} C++\033[0m";
             clean-${lib}-cpp "${OPTS[@]}";
         fi
     done
     for lib in ${PY_LIB}; do
         if command -V clean-${lib}-python >/dev/null 2>&1; then
+            echo -e "\033[1;36mCleaning ${lib} Python\033[0m";
             clean-${lib}-python "${OPTS[@]}";
         fi
     done

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.configure.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.configure.tmpl.sh
@@ -24,6 +24,7 @@ configure_${NAME}() {
 
     for lib in ${CPP_LIB}; do
         if command -V configure-${lib}-cpp >/dev/null 2>&1; then
+            echo -e "\033[1;36mConfiguring ${lib} C++\033[0m";
             configure-${lib}-cpp "${OPTS[@]}";
         fi
     done

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.cpack.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.cpack.tmpl.sh
@@ -30,6 +30,7 @@ cpack_${NAME}() {
 
     for lib in ${CPP_LIB}; do
         if command -V cpack-${lib}-cpp >/dev/null 2>&1; then
+            echo -e "\033[1;36mCPacking ${lib} C++\033[0m";
             cpack-${lib}-cpp "${OPTS[@]}";
         fi
     done

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.install.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.install.tmpl.sh
@@ -21,6 +21,7 @@ install_${NAME}() {
 
     for lib in ${CPP_LIB}; do
         if command -V install-${lib}-cpp >/dev/null 2>&1; then
+            echo -e "\033[1;36mInstalling ${lib} C++\033[0m";
             install-${lib}-cpp "${OPTS[@]}";
         fi
     done

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.uninstall.tmpl.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/tmpl/repo.uninstall.tmpl.sh
@@ -27,12 +27,14 @@ uninstall_${NAME}() {
 
     for lib in ${CPP_LIB}; do
         if command -V uninstall-${lib}-cpp >/dev/null 2>&1; then
+            echo -e "\033[1;36mUninstalling ${lib} C++\033[0m";
             uninstall-${lib}-cpp "${OPTS[@]}";
         fi
     done
 
     for lib in ${PY_LIB}; do
         if command -V uninstall-${lib}-python >/dev/null 2>&1; then
+            echo -e "\033[1;36mUninstalling ${lib} Python\033[0m";
             uninstall-${lib}-python "${OPTS[@]}";
         fi
     done


### PR DESCRIPTION
## Summary
- Extends the approach from #634 to the remaining repo-level commands
- When running configure-all, clean-all, cpack-all, install-all, or uninstall-all, a cyan-colored message now appears before each operation to identify which library is being processed