### PR TITLE
Add nvfatbin to CUDA installation script

### DIFF
--- a/windows/image/installers/install-cuda.ps1
+++ b/windows/image/installers/install-cuda.ps1
@@ -38,6 +38,7 @@ $cudaComponents = @(
     "cuxxfilt_$mmVersionTag",
     "nvcc_$mmVersionTag",
     "nvdisasm_$mmVersionTag",
+    "nvfatbin_$mmVersionTag",
     "nvjitlink_$mmVersionTag",
     "nvml_dev_$mmVersionTag",
     "nvrtc_$mmVersionTag",

--- a/windows/image/installers/install-cuda.ps1
+++ b/windows/image/installers/install-cuda.ps1
@@ -54,7 +54,7 @@ if ([int]$major -eq 12 -and [int]$minor -ge 4) {
 # The following components first appeared in 13.0.
 if ([int]$major -ge 13) {
     $cudaComponents += "crt_$mmVersionTag"
-    $cudaComponents += "nvfatbin_$mmVersionTag",
+    $cudaComponents += "nvfatbin_$mmVersionTag"
     $cudaComponents += "nvvm_$mmVersionTag"
     $cudaComponents += "nvptxcompiler_$mmVersionTag"
 }

--- a/windows/image/installers/install-cuda.ps1
+++ b/windows/image/installers/install-cuda.ps1
@@ -38,7 +38,6 @@ $cudaComponents = @(
     "cuxxfilt_$mmVersionTag",
     "nvcc_$mmVersionTag",
     "nvdisasm_$mmVersionTag",
-    "nvfatbin_$mmVersionTag",
     "nvjitlink_$mmVersionTag",
     "nvml_dev_$mmVersionTag",
     "nvrtc_$mmVersionTag",
@@ -55,6 +54,7 @@ if ([int]$major -eq 12 -and [int]$minor -ge 4) {
 # The following components first appeared in 13.0.
 if ([int]$major -ge 13) {
     $cudaComponents += "crt_$mmVersionTag"
+    $cudaComponents += "nvfatbin_$mmVersionTag",
     $cudaComponents += "nvvm_$mmVersionTag"
     $cudaComponents += "nvptxcompiler_$mmVersionTag"
 }


### PR DESCRIPTION
Adds nvfatbin to 13.0+ builds. Semantic versioning check failed after 13.0.