### PR TITLE
ensure latest tag is used to determine versions

### DIFF
--- a/.github/actions/devcontainer-json/action.sh
+++ b/.github/actions/devcontainer-json/action.sh
@@ -7,7 +7,7 @@ os="${1:-"ubuntu:22.04"}";
 features="${2:-"[]"}";
 container_env="${3:-"null"}";
 
-VERSION="$(git describe --abbrev=0 --tags | sed 's/[a-zA-Z]//g' | cut -d '.' -f -2)";
+VERSION="$(git describe --abbrev=0 --tags --first-parent | sed 's/[a-zA-Z]//g' | cut -d '.' -f -2)";
 tag="$(node -p "$(cat <<EOF
 ['cpp', ...${features}.filter((x) => !x.hide).map(({ name = '', version = '', suffix = '' }) => {
     if (name.includes(':')) {

--- a/.github/workflows/build-test-and-push-windows-image.yml
+++ b/.github/workflows/build-test-and-push-windows-image.yml
@@ -54,7 +54,7 @@ jobs:
           repo="$INPUT_REPO";
           cl="$(echo "$INPUT_FEATURES" | jq -r '.[1].version')";
           cuda="$(echo "$INPUT_FEATURES" | jq -r '.[0].version')";
-          version="$(git describe --abbrev=0 --tags | sed 's/[a-zA-Z]//g' | cut -d '.' -f -2)";
+          version="$(git describe --abbrev=0 --tags --first-parent | sed 's/[a-zA-Z]//g' | cut -d '.' -f -2)";
           base_tag="cuda${cuda}-cl${cl}";
           tag_without_os="${version}-${base_tag}";
           cat <<EOF | tee "$GITHUB_OUTPUT"


### PR DESCRIPTION
Contributes to https://github.com/rapidsai/github-infrastructure/issues/63

Mistakes in forward-mergers can sometimes lead to a weird mix of tags in `git` history, which can trip up logic that relies on those tags to compute things like versions for image URIs.

`git describe --tags --first-parent` ensures we get the expected behavior (version = tag "closest" to HEAD) even when mistakes are made in the forward-merger process.

See https://github.com/rapidsai/docker/pull/867 and https://github.com/rapidsai/github-infrastructure/issues/63 for much more detail.

## Notes for Reviewers

### How I tested this

These commands are equivalent on `main` here.

```console
$ git checkout main
$ git fetch upstream --tags
$ git describe --abbrev=0 --tags
v26.06.00a

$ git describe --abbrev=0 --tags --first-parent
v26.06.00a
```

Just doing this preventatively.