### PR TITLE
Don't prune libnvidia-ml.a

### DIFF
--- a/features/src/cuda/prune-static-libs.sh
+++ b/features/src/cuda/prune-static-libs.sh
@@ -17,7 +17,7 @@ find /usr/lib/                                       \
 for dir in "lib" "lib64"; do
     if [ -d "${CUDA_HOME}/${dir}/" ]; then
         find "$(realpath -m "${CUDA_HOME}/${dir}")/" -type f \
-            \( -name '*.a' ! -name 'libnvptxcompiler_static.a' ! -name 'libcudart_static.a' ! -name 'libcudadevrt.a' ! -name 'libculibos.a' ! -name 'libcufilt.a' \) \
+            \( -name '*.a' ! -name 'libnvptxcompiler_static.a' ! -name 'libcudart_static.a' ! -name 'libcudadevrt.a' ! -name 'libculibos.a' ! -name 'libcufilt.a' ! -name 'libnvidia-ml.a' \) \
             -delete || true;
     fi
 done


### PR DESCRIPTION
`libnvidia-ml.a` is a stub library that dynamically loads `libnvidia-ml.so`, similar to how `libcudart.a` dynamically loads `libcuda.so`. We want to use it in some projects, so don't prune it.