### PR TITLE
Switch from building RMM to building CCCL in UCXX

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "26.8.0",
+  "version": "26.8.1",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -31,7 +31,7 @@ repos:
       - name: ucxx
         sub_dir: cpp
         depends: [rmm]
-        args: {cmake: -DUCXX_ENABLE_RMM=ON}
+        args: {cmake: -DUCXX_ENABLE_CCCL=ON}
         test: ci/run_cpp.sh
       - name: ucxx-python
         sub_dir: cpp/python


### PR DESCRIPTION
CCCL support for UCXX was added in https://github.com/rapidsai/ucxx/pull/641, and https://github.com/rapidsai/ucxx/pull/656 is removing RMM support. Switching to CCCL here is necessary.