### PR TITLE
Add nvforest to cuML devcontainer dependencies

### DIFF
--- a/.github/workflows/build-all-rapids-repos.yml
+++ b/.github/workflows/build-all-rapids-repos.yml
@@ -43,7 +43,7 @@ jobs:
       matrix:
         include:
           - libs: "rmm ucxx kvikio dask-cuda cudf cudf_kafka rapidsmpf"
-          - libs: "rmm ucxx dask-cuda raft cuvs cuml nvforest cuopt"
+          - libs: "rmm ucxx dask-cuda raft cuvs nvforest cuml cuopt"
           - libs: "rmm ucxx dask-cuda raft cugraph cugraph-gnn nx-cugraph"
 
     with:

--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "26.6.1",
+  "version": "26.6.2",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -194,7 +194,7 @@ repos:
     cpp:
       - name: cuml
         sub_dir: cpp
-        depends: [rmm, raft, cuvs]
+        depends: [rmm, raft, cuvs, nvforest]
         parallelism:
           max_device_obj_memory_usage: 3Gi
         test: ci/run_ctests.sh

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -186,28 +186,6 @@ repos:
         depends: [cuvs]
         args: {install: *rapids_build_backend_args}
         test: ci/run_cuvs_pytests.sh
-  - name: cuml
-    path: cuml
-    git: {!!merge <<: *git_defaults, repo: cuml}
-    dependency_keys:
-      - devcontainers
-    cpp:
-      - name: cuml
-        sub_dir: cpp
-        depends: [rmm, raft, cuvs, nvforest]
-        parallelism:
-          max_device_obj_memory_usage: 3Gi
-        test: ci/run_ctests.sh
-    python:
-      - name: libcuml
-        sub_dir: python/libcuml
-        depends: [cuml]
-        args: {install: *rapids_build_backend_args}
-      - name: cuml
-        sub_dir: python/cuml
-        depends: [cuml]
-        args: {install: *rapids_build_backend_args}
-        test: ci/run_cuml_singlegpu_pytests.sh
   - name: nvforest
     path: nvforest
     git: {!!merge <<: *git_defaults, repo: nvforest}
@@ -230,6 +208,28 @@ repos:
         depends: [nvforest]
         args: {install: *rapids_build_backend_args}
         test: ci/run_nvforest_pytests.sh
+  - name: cuml
+    path: cuml
+    git: {!!merge <<: *git_defaults, repo: cuml}
+    dependency_keys:
+      - devcontainers
+    cpp:
+      - name: cuml
+        sub_dir: cpp
+        depends: [rmm, raft, cuvs, nvforest]
+        parallelism:
+          max_device_obj_memory_usage: 3Gi
+        test: ci/run_ctests.sh
+    python:
+      - name: libcuml
+        sub_dir: python/libcuml
+        depends: [cuml]
+        args: {install: *rapids_build_backend_args}
+      - name: cuml
+        sub_dir: python/cuml
+        depends: [cuml]
+        args: {install: *rapids_build_backend_args}
+        test: ci/run_cuml_singlegpu_pytests.sh
   - name: cugraph
     path: cugraph
     git: {!!merge <<: *git_defaults, repo: cugraph}


### PR DESCRIPTION
Add `nvforest` to the cuML C++ devcontainer dependency list so cuML builds after nvForest when using the RAPIDS build-utils manifest.

Follow-up to https://github.com/rapidsai/cuml/pull/8048
