### PR TITLE
Add new cudf-streaming C++ and Python builds

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "26.8.3",
+  "version": "26.8.4",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -146,6 +146,10 @@ repos:
         sub_dir: python/libcudf_streaming
         depends: [cudf_streaming]
         args: {install: *rapids_build_backend_args}
+      - name: cudf-streaming
+        sub_dir: python/cudf_streaming
+        depends: [cudf_streaming]
+        args: {install: *rapids_build_backend_args}
   - name: raft
     path: raft
     git: {!!merge <<: *git_defaults, repo: raft}

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -75,6 +75,26 @@ repos:
         depends: [kvikio]
         args: {install: *rapids_build_backend_args}
         test: ci/run_pytests.sh
+  - name: rapidsmpf
+    path: rapidsmpf
+    git: {!!merge <<: *git_defaults, repo: rapidsmpf}
+    dependency_keys:
+      - devcontainers
+    cpp:
+      - name: rapidsmpf
+        sub_dir: cpp
+        depends: [rmm, ucxx]
+        test: ci/run_ctests.sh
+    python:
+      - name: librapidsmpf
+        sub_dir: python/librapidsmpf
+        depends: [rapidsmpf]
+        args: {install: *rapids_build_backend_args}
+      - name: rapidsmpf
+        sub_dir: python/rapidsmpf
+        depends: [rapidsmpf, ucxx-python]
+        args: {install: *rapids_build_backend_args}
+        test: ci/run_pytests.sh
   - name: cudf
     path: cudf
     git: {!!merge <<: *git_defaults, repo: cudf}
@@ -126,26 +146,6 @@ repos:
         sub_dir: python/libcudf_streaming
         depends: [cudf_streaming]
         args: {install: *rapids_build_backend_args}
-  - name: rapidsmpf
-    path: rapidsmpf
-    git: {!!merge <<: *git_defaults, repo: rapidsmpf}
-    dependency_keys:
-      - devcontainers
-    cpp:
-      - name: rapidsmpf
-        sub_dir: cpp
-        depends: [rmm, ucxx, cudf]
-        test: ci/run_ctests.sh
-    python:
-      - name: librapidsmpf
-        sub_dir: python/librapidsmpf
-        depends: [rapidsmpf]
-        args: {install: *rapids_build_backend_args}
-      - name: rapidsmpf
-        sub_dir: python/rapidsmpf
-        depends: [rapidsmpf, ucxx-python]
-        args: {install: *rapids_build_backend_args}
-        test: ci/run_pytests.sh
   - name: raft
     path: raft
     git: {!!merge <<: *git_defaults, repo: raft}

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -87,6 +87,9 @@ repos:
         sub_dir: cpp/libcudf_kafka
         depends: [cudf]
         test: ci/run_cudf_kafka_ctests.sh
+      - name: cudf_streaming
+        sub_dir: cpp/libcudf_streaming
+        depends: [cudf, rapidsmpf]
     python:
       - name: libcudf
         sub_dir: python/libcudf
@@ -119,6 +122,10 @@ repos:
         sub_dir: python/custreamz
         args: {install: *rapids_build_backend_args}
         test: ci/run_custreamz_pytests.sh
+      - name: libcudf_streaming
+        sub_dir: python/libcudf_streaming
+        depends: [cudf_streaming]
+        args: {install: *rapids_build_backend_args}
   - name: rapidsmpf
     path: rapidsmpf
     git: {!!merge <<: *git_defaults, repo: rapidsmpf}


### PR DESCRIPTION
These new libraries contain the pieces of rapidsmpf that rely on cudf. As a result, the dependency ordering is also now switched because rapidsmpf will no longer rely on cudf. 