### PR TITLE
Support git worktrees in RAPIDS script generation

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "26.8.4",
+  "version": "26.8.5",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/checkout-same-branch.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/checkout-same-branch.sh
@@ -17,6 +17,11 @@
 # shellcheck disable=SC1091
 . rapids-generate-docstring;
 
+repo_exists() {
+    local repo_path="${1:-}";
+    git -C "${repo_path}" rev-parse --is-inside-work-tree >/dev/null 2>&1;
+}
+
 # Function to convert ucx branch names
 convert-ucx-branch() {
     repo=$1
@@ -61,7 +66,7 @@ checkout_same_branch() {
         local repo="repos_${i}";
         local repo_name="${repo}_name";
         local repo_path="${repo}_path";
-        if [[ ! -d ~/"${!repo_path:-}/.git" ]]; then
+        if ! repo_exists ~/"${!repo_path:-}"; then
             continue;
         fi
         local name="${!repo_name}";
@@ -146,7 +151,7 @@ checkout_same_branch() {
         local repo_name="${repo}_name";
         local repo_path="${repo}_path";
 
-        if [[ ! -d ~/"${!repo_path:-}/.git" ]]; then
+        if ! repo_exists ~/"${!repo_path:-}"; then
             continue;
         fi
 

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/generate-scripts.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/generate-scripts.sh
@@ -96,6 +96,11 @@ generate_all_script() {
     fi
 }
 
+repo_exists() {
+    local repo_path="${1:-}";
+    git -C "${repo_path}" rev-parse --is-inside-work-tree >/dev/null 2>&1;
+}
+
 generate_clone_script() {
     if test -f "${TEMPLATES}/repo.clone.tmpl.sh"; then (
         # shellcheck disable=SC2002
@@ -269,7 +274,7 @@ generate_scripts() {
         repo_name="${!repo_name,,}";
         repo_names+=("${repo_name}");
 
-        if [[ -d ~/"${!repo_path:-}/.git" ]]; then
+        if repo_exists ~/"${!repo_path:-}"; then
             cloned_repos+=("${repo_name}");
         fi
 
@@ -318,7 +323,7 @@ generate_scripts() {
 
             cpp_name_to_deps["${cpp_name}"]="${cpp_deps[*]}";
 
-            if [[ -d ~/"${!repo_path:-}/.git" ]]; then
+            if repo_exists ~/"${!repo_path:-}"; then
                 NAME="${repo_name:-}"                                                                       \
                 SRC_PATH=~/"${!repo_path:-}"                                                                \
                 BIN_DIR="${bin_dir}"                                                                        \
@@ -377,7 +382,7 @@ generate_scripts() {
             py_name="${!py_name:-}";
             py_libs+=("${py_name}");
 
-            if [[ -d ~/"${!repo_path:-}/.git" ]]; then
+            if repo_exists ~/"${!repo_path:-}"; then
                 NAME="${repo_name:-}"                     \
                 BIN_DIR="${bin_dir}"                      \
                 SRC_PATH=~/"${!repo_path:-}"              \
@@ -399,7 +404,7 @@ generate_scripts() {
 
         py_names+=("${py_libs[@]}");
 
-        if [[ -d ~/"${!repo_path:-}/.git" ]]; then
+        if repo_exists ~/"${!repo_path:-}"; then
             NAME="${repo_name:-}"      \
             PY_LIB="${py_libs[*]@Q}"   \
             CPP_LIB="${cpp_libs[*]@Q}" \

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-vscode-workspace.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/make-vscode-workspace.sh
@@ -19,7 +19,7 @@ get_repos() {
 }
 
 with_git_dirs() {
-    cat - | xargs -r -d'\n' -I% bash -c 'if [ -d ~/%/.git ]; then echo %; fi;';
+    cat - | xargs -r -d'\n' -I% bash -c 'if git -C ~/% rev-parse --is-inside-work-tree >/dev/null 2>&1; then echo %; fi;';
 }
 
 lib_entries() {

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/merge-compile-commands-json.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/merge-compile-commands-json.sh
@@ -14,6 +14,11 @@
 # shellcheck disable=SC1091
 . rapids-generate-docstring;
 
+repo_exists() {
+    local repo_path="${1:-}";
+    git -C "${repo_path}" rev-parse --is-inside-work-tree >/dev/null 2>&1;
+}
+
 _list_repo_paths() {
     for ((i=0; i < ${repos_length:-0}; i+=1)); do
 
@@ -22,7 +27,7 @@ _list_repo_paths() {
         local cpp_length="${repo}_cpp_length";
         local py_length="${repo}_python_length";
 
-        if test -d ~/"${!repo_path:-}/.git"; then
+        if repo_exists ~/"${!repo_path:-}"; then
 
             for ((j=0; j < ${!cpp_length:-0}; j+=1)); do
                 local cpp_sub_dir="${repo}_cpp_${j}_sub_dir";

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/pull-repositories.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/pull-repositories.sh
@@ -18,6 +18,11 @@
 # shellcheck disable=SC1091
 . rapids-generate-docstring;
 
+repo_exists() {
+    local repo_path="${1:-}";
+    git -C "${repo_path}" rev-parse --is-inside-work-tree >/dev/null 2>&1;
+}
+
 pull_repositories() {
     local -;
     set -euo pipefail;
@@ -38,7 +43,7 @@ pull_repositories() {
         local repo_name="${repo}_name";
         local repo_path="${repo}_path";
 
-        if [[ ! -d ~/"${!repo_path:-}/.git" ]]; then
+        if ! repo_exists ~/"${!repo_path:-}"; then
             continue;
         fi;
 

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/push-repositories.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/push-repositories.sh
@@ -14,6 +14,11 @@
 # shellcheck disable=SC1091
 . rapids-generate-docstring;
 
+repo_exists() {
+    local repo_path="${1:-}";
+    git -C "${repo_path}" rev-parse --is-inside-work-tree >/dev/null 2>&1;
+}
+
 push_repositories() {
     local -;
     set -euo pipefail;
@@ -31,7 +36,7 @@ push_repositories() {
         local repo_name="${repo}_name";
         local repo_path="${repo}_path";
 
-        if [[ ! -d ~/"${!repo_path:-}/.git" ]]; then
+        if ! repo_exists ~/"${!repo_path:-}"; then
             continue;
         fi
 

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-conda-pkg-names.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-conda-pkg-names.sh
@@ -17,6 +17,11 @@
 # shellcheck disable=SC1091
 . rapids-generate-docstring;
 
+repo_exists() {
+    local repo_path="${1:-}";
+    git -C "${repo_path}" rev-parse --is-inside-work-tree >/dev/null 2>&1;
+}
+
 _python_conda_pkg_names() {
     local -;
     set -euo pipefail;
@@ -35,7 +40,7 @@ _python_conda_pkg_names() {
         local repo="repos_${i}";
         local repo_path="${repo}_path";
 
-        if test -d ~/"${!repo_path:-}/.git"; then
+        if repo_exists ~/"${!repo_path:-}"; then
             # the regex will continue until morale improves
             find ~/"${!repo_path}/"            \
               -type f                          \

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-pkg-names.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-pkg-names.sh
@@ -14,6 +14,11 @@
 # shellcheck disable=SC1091
 . rapids-generate-docstring;
 
+repo_exists() {
+    local repo_path="${1:-}";
+    git -C "${repo_path}" rev-parse --is-inside-work-tree >/dev/null 2>&1;
+}
+
 python_pkg_names() {
     local -;
     set -euo pipefail;
@@ -34,7 +39,7 @@ python_pkg_names() {
         local repo_path="${repo}_path";
         local py_length="${repo}_python_length";
 
-        if test -d ~/"${!repo_path:-}/.git"; then
+        if repo_exists ~/"${!repo_path:-}"; then
             for ((j=0; j < ${!py_length:-0}; j+=1)); do
                 local py_name="${repo}_python_${j}_name";
                 echo "${!py_name}";

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-pkg-roots.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/python-pkg-roots.sh
@@ -14,6 +14,11 @@
 # shellcheck disable=SC1091
 . rapids-generate-docstring;
 
+repo_exists() {
+    local repo_path="${1:-}";
+    git -C "${repo_path}" rev-parse --is-inside-work-tree >/dev/null 2>&1;
+}
+
 python_pkg_roots() {
     local -;
     set -euo pipefail;
@@ -34,7 +39,7 @@ python_pkg_roots() {
         local repo_path="${repo}_path";
         local py_length="${repo}_python_length";
 
-        if test -d ~/"${!repo_path:-}/.git"; then
+        if repo_exists ~/"${!repo_path:-}"; then
             for ((j=0; j < ${!py_length:-0}; j+=1)); do
                 local py_sub_dir="${repo}_python_${j}_sub_dir";
                 echo "${!repo_path:-}${!py_sub_dir:+/${!py_sub_dir}}";

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/bin/update-build-dir-links.sh
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/bin/update-build-dir-links.sh
@@ -16,6 +16,11 @@
 # shellcheck disable=SC1091
 . rapids-generate-docstring;
 
+repo_exists() {
+    local repo_path="${1:-}";
+    git -C "${repo_path}" rev-parse --is-inside-work-tree >/dev/null 2>&1;
+}
+
 _get_library_paths() {
     local i;
     local j;
@@ -27,7 +32,7 @@ _get_library_paths() {
         local cpp_length="${repo}_cpp_length";
         local py_length="${repo}_python_length";
 
-        if test -d ~/"${!repo_path:-}/.git"; then
+        if repo_exists ~/"${!repo_path:-}"; then
 
             for ((j=0; j < ${!cpp_length:-0}; j+=1)); do
                 local cpp_sub_dir="${repo}_cpp_${j}_sub_dir";

--- a/features/src/utils/devcontainer-feature.json
+++ b/features/src/utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "devcontainer-utils",
   "id": "utils",
-  "version": "26.8.1",
+  "version": "26.8.2",
   "description": "A feature to install RAPIDS devcontainer utility scripts",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/utils/opt/devcontainer/bin/git/repo/clone.sh
+++ b/features/src/utils/opt/devcontainer/bin/git/repo/clone.sh
@@ -33,6 +33,11 @@ clone_git_repo() {
     local origin;
     local directory;
 
+    repo_exists() {
+        local repo_path="${1:-}";
+        git -C "${repo_path}" rev-parse --is-inside-work-tree >/dev/null 2>&1;
+    }
+
     local nargs="${#REST[@]}";
 
     if test "${nargs}" -gt 1; then
@@ -52,7 +57,7 @@ clone_git_repo() {
         local re="(ssh:\/\/|https:\/\/)?(git@)?(.*\.com)[:\/](.*)";
         if [[ "${origin}" =~ ${re} ]]; then
             directory="$(basename "${BASH_REMATCH[4]//.git/}")";
-        elif test -d "${origin}" && test -d "${origin}"/.git; then
+        elif test -d "${origin}" && repo_exists "${origin}"; then
             directory="$(basename "${origin}")";
         else
             echo "fatal: '${origin}' is not a git repository" 1>&2;
@@ -66,7 +71,7 @@ clone_git_repo() {
     upstream="${upstream:-"${origin}"}";
     directory="$(realpath -m "${directory}")";
 
-    if ! test -d "${directory}"/.git; then
+    if ! repo_exists "${directory}"; then
         git clone "${qj[@]}" "${OPTS[@]}" -- "${origin}" "${directory}";
     fi
 


### PR DESCRIPTION
## Summary
- Detect checked-out RAPIDS repos with `git -C <path> rev-parse --is-inside-work-tree` instead of testing for a `.git` directory
- Allow RAPIDS build utility scripts to recognize git worktrees, where `.git` is a file instead of a directory
- Update the shared clone helper so local worktree origins and existing worktree targets are treated as git repositories
- Bump `rapids-build-utils` from `26.8.4` to `26.8.5` and `utils` from `26.8.1` to `26.8.2`

## Motivation
This is necessary to support devcontainers that use git worktrees. Worktree checkouts store `.git` as a file pointing at the real git metadata, so the previous `-d <repo>/.git` checks treated valid worktree repos as missing. In `rapids-generate-scripts`, that meant only aggregate/no-op scripts were generated.

## Testing
- `bash -n` passed for the 10 modified shell scripts
- `git diff --check` passed
- confirmed there are no remaining `.git` directory predicates in the repo
- created a temporary git worktree inside the devcontainer and verified the updated clone helper accepts it as a local git repository
- patched the installed script in an RMM worktree devcontainer and verified `rapids-generate-scripts --repo rmm` generated `build-rmm` and `test-rmm-python`
- in the RMM worktree devcontainer, `build-all -j0` passed
- in the RMM worktree devcontainer, `test-all-python` passed: `1780 passed, 6 skipped`