### PR TITLE
Fix loop when regenerating expired S3 credentials

### DIFF
--- a/.devcontainer/rapids.Dockerfile
+++ b/.devcontainer/rapids.Dockerfile
@@ -65,6 +65,7 @@ ENV SCCACHE_REGION="us-east-2"
 ENV SCCACHE_BUCKET="rapids-sccache-devs"
 ENV SCCACHE_S3_USE_PREPROCESSOR_CACHE_MODE=true
 ENV SCCACHE_IDLE_TIMEOUT=0
+ENV SCCACHE_SERVER_LOG=sccache=debug
 
 ###
 # sccache-dist configuration

--- a/features/src/utils/devcontainer-feature.json
+++ b/features/src/utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "devcontainer-utils",
   "id": "utils",
-  "version": "26.8.1",
+  "version": "26.8.2",
   "description": "A feature to install RAPIDS devcontainer utility scripts",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/utils/opt/devcontainer/bin/creds/s3/gh/generate.sh
+++ b/features/src/utils/opt/devcontainer/bin/creds/s3/gh/generate.sh
@@ -46,6 +46,10 @@ _creds_github_generate() {
 
     mkdir -p ~/.aws;
 
+    if test -w ~/.aws; then
+        rm -f ~/.aws/stamp;
+    fi
+
     for org in "${user_orgs[@]}"; do
         generated_at="$(date '+%s')";
         if gh nv-gha-aws org "${org}" "${nv_gha_aws_args[@]}" >"${HOME}/.aws/credentials" 2>>/var/log/devcontainer-utils/creds-s3.log; then

--- a/features/src/utils/opt/devcontainer/bin/sccache/start.sh
+++ b/features/src/utils/opt/devcontainer/bin/sccache/start.sh
@@ -62,7 +62,7 @@ _start_sccache() {
         SCCACHE_ERROR_LOG="${logfile}"          \
         SCCACHE_SERVER_LOG="${log_lvl}"         \
         SCCACHE_SERVER_PORT="${sccache_port}"   \
-        sccache --start-server 1>&2 2>/dev/null \
+        sccache --start-server 1>&2             \
       | tee "$logfile";
 
         # If the pidfile doesn't exist, write it


### PR DESCRIPTION
Fixes a loop when regenerating expired S3 credentials caused by not removing the previous `~/.aws/stamp` file before testing whether the new creds are valid. Also don't redirect stderr for sccache server startup, so startup errors are surfaced in logs.