### PR TITLE
Use CMake tarball instead of shell script

### DIFF
--- a/features/src/cmake/devcontainer-feature.json
+++ b/features/src/cmake/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "CMake",
   "id": "cmake",
-  "version": "26.8.1",
+  "version": "26.8.2",
   "description": "A feature to install CMake",
   "options": {
     "version": {

--- a/features/src/cmake/install.sh
+++ b/features/src/cmake/install.sh
@@ -15,22 +15,22 @@ echo "Downloading CMake...";
 
 if [[ "${CMAKE_VERSION}" == "latest" ]]; then
     find_version_from_git_tags CMAKE_VERSION https://github.com/Kitware/CMake;
-    while ! wget --no-hsts -q -O /tmp/cmake_${CMAKE_VERSION}.sh https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).sh; do
+    while ! wget --no-hsts -q -O "/tmp/cmake_${CMAKE_VERSION}.tar.gz" "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).tar.gz"; do
         echo "(!) cmake version ${CMAKE_VERSION} failed to download. Attempting to fall back one version to retry...";
         find_prev_version_from_git_tags CMAKE_VERSION https://github.com/Kitware/CMake;
     done
 else
-    wget --no-hsts -q -O /tmp/cmake_${CMAKE_VERSION}.sh https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).sh;
+    wget --no-hsts -q -O "/tmp/cmake_${CMAKE_VERSION}.tar.gz" "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VERSION}/cmake-${CMAKE_VERSION}-linux-$(uname -m).tar.gz";
 fi
 
 echo "Installing CMake...";
 
 # Install CMake
-bash /tmp/cmake_${CMAKE_VERSION}.sh --skip-license --exclude-subdir --prefix=/usr;
+tar -C /usr -xzvf "/tmp/cmake_${CMAKE_VERSION}.tar.gz" --strip-components=1
 
 # Clean up
 # rm -rf /tmp/*;
 rm -rf /var/tmp/*;
 rm -rf /var/cache/apt/*;
 rm -rf /var/lib/apt/lists/*;
-rm -rf /tmp/cmake_${CMAKE_VERSION}.sh;
+rm -rf "/tmp/cmake_${CMAKE_VERSION}.tar.gz";

--- a/features/src/cmake/install.sh
+++ b/features/src/cmake/install.sh
@@ -26,7 +26,7 @@ fi
 echo "Installing CMake...";
 
 # Install CMake
-tar -C /usr -xzvf "/tmp/cmake_${CMAKE_VERSION}.tar.gz" --strip-components=1
+cat "/tmp/cmake_${CMAKE_VERSION}.tar.gz" | tar -C /usr -xzvf - --strip-components=1
 
 # Clean up
 # rm -rf /tmp/*;


### PR DESCRIPTION
Seeing sporadic errors using the self-extracting shell script in Ubuntu 26.04, so switch CMake install to use the `.tar.gz` instead.