### PR TITLE
Specify `use_cuda_wheels`

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "26.10.0",
+  "version": "26.10.1",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -5,7 +5,7 @@ x-git-defaults: &git_defaults
 x-rapids-build-backend-args: &rapids_build_backend_args |
   --config-settings "skbuild.strict-config=false"
   --config-settings "rapidsai.disable-cuda=true"
-  --config-settings "rapidsai.matrix-entry=cuda=${CUDA_VERSION_MAJOR_MINOR};use_cuda_wheels=true;cuda_suffixed=false"
+  --config-settings "rapidsai.matrix-entry=cuda=${CUDA_VERSION_MAJOR_MINOR};use_cuda_wheels=false"
 repos:
   - name: rmm
     path: rmm

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -5,7 +5,7 @@ x-git-defaults: &git_defaults
 x-rapids-build-backend-args: &rapids_build_backend_args |
   --config-settings "skbuild.strict-config=false"
   --config-settings "rapidsai.disable-cuda=true"
-  --config-settings "rapidsai.matrix-entry=cuda=${CUDA_VERSION_MAJOR_MINOR}"
+  --config-settings "rapidsai.matrix-entry=cuda=${CUDA_VERSION_MAJOR_MINOR};use_cuda_wheels=true;cuda_suffixed=false"
 repos:
   - name: rmm
     path: rmm


### PR DESCRIPTION
In order to support https://github.com/rapidsai/pre-commit-hooks/issues/132, matrix parameters like `use_cuda_wheels` have to be explicit so that the `verify-dependencies` hook doesn't produce false positives. Make it explicit so we can use the hook.