### PR TITLE
Specify `cuda_suffixed=false`

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "26.10.1",
+  "version": "26.10.2",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -5,7 +5,7 @@ x-git-defaults: &git_defaults
 x-rapids-build-backend-args: &rapids_build_backend_args |
   --config-settings "skbuild.strict-config=false"
   --config-settings "rapidsai.disable-cuda=true"
-  --config-settings "rapidsai.matrix-entry=cuda=${CUDA_VERSION_MAJOR_MINOR};use_cuda_wheels=false"
+  --config-settings "rapidsai.matrix-entry=cuda=${CUDA_VERSION_MAJOR_MINOR};use_cuda_wheels=false;cuda_suffixed=false"
 repos:
   - name: rmm
     path: rmm


### PR DESCRIPTION
The fallback entries in `dependencies.yaml` previously had an implicit `cuda_suffixed: "false"` that we didn't need to specify here. Since it is now explicit, we have to specify it here too.