### PR TITLE
Require DFG >=1.22

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "26.10.2",
+  "version": "26.10.3",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/install.sh
+++ b/features/src/rapids-build-utils/install.sh
@@ -46,7 +46,7 @@ fi
 python3 -m pip install "${_PIP_INSTALL_ARGS[@]}" "${_PIP_UPGRADE_ARGS[@]}" pip;
 # Install RAPIDS dependency file generator, conda-merge, and toml
 python3 -m pip install "${_PIP_INSTALL_ARGS[@]}" \
-    'rapids-dependency-file-generator' \
+    'rapids-dependency-file-generator==1.*,>=1.22' \
     conda-merge \
     toml;
 


### PR DESCRIPTION
In order for projects to use the new `constraints` output type in v1.22.0, we have to ensure that rapids-dependency-file-generator is always v1.22.0 or greater.

Contributes to https://github.com/rapidsai/build-planning/issues/311