### PR TITLE
Set cuda_suffixed=false;use_cuda_wheels=false in devcontainers dependency generation

### DIFF
--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -5,7 +5,7 @@ x-git-defaults: &git_defaults
 x-rapids-build-backend-args: &rapids_build_backend_args |
   --config-settings "skbuild.strict-config=false"
   --config-settings "rapidsai.disable-cuda=true"
-  --config-settings "rapidsai.matrix-entry=cuda=${CUDA_VERSION_MAJOR_MINOR}"
+  --config-settings "rapidsai.matrix-entry=cuda=${CUDA_VERSION_MAJOR_MINOR};cuda_suffixed=false;use_cuda_wheels=false"
 repos:
   - name: rmm
     path: rmm


### PR DESCRIPTION
We are adopting a new convention where dependency lists explicitly require `cuda_suffixed` and `use_cuda_wheels` to be set. Currently cudf devcontainers fail on the `depends_on_kvikio` list when only the CUDA version is set and the suffix/wheels settings are left unset. This sets those values explicitly to help `rapids-dependency-file-generator` do the right thing.
