### PR TITLE
rapids-build-utils: make cuVS builds depend on kvikio

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "26.10.3",
+  "version": "26.10.4",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -182,7 +182,7 @@ repos:
     cpp:
       - name: cuvs
         sub_dir: cpp
-        depends: [rmm, raft]
+        depends: [kvikio, rmm, raft]
         parallelism:
           max_device_obj_memory_usage: 3Gi
         args: {cmake: -DBUILD_C_LIBRARY=ON}


### PR DESCRIPTION
https://github.com/NVIDIA/cuvs/pull/2257 makes `kvikio` a build-time dependency of `cuvs`

Whenever that PR's merged, this should be too, to ensure `kvikio` nightlies are built before cuVS's.