### PR TITLE
Use default dependency key for RapidsMPF

### DIFF
--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "26.10.3",
+  "version": "26.10.4",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
+++ b/features/src/rapids-build-utils/opt/rapids-build-utils/manifest.yaml
@@ -78,8 +78,6 @@ repos:
   - name: rapidsmpf
     path: rapidsmpf
     git: {!!merge <<: *git_defaults, repo: rapidsmpf}
-    dependency_keys:
-      - devcontainers
     cpp:
       - name: rapidsmpf
         sub_dir: cpp


### PR DESCRIPTION
Remove RapidsMPF's `dependency_keys` override so `rapids-build-utils` uses the default `all` key.

`ray-default>=2.55.1` now resolves with PyTorch on both `linux-64` and `linux-aarch64`, so the workaround introduced for rapidsai/rapidsmpf#906 is no longer needed.
