### PR TITLE
Require patch bumps for feature changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Agent Instructions
+
+## Feature versions
+
+When modifying an existing feature under `features/src/<feature>/`, increment the patch component of that feature's `devcontainer-feature.json` version in the same pull request. Increment it once per feature per pull request, regardless of how many files or commits modify the feature.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,5 @@
 ## Feature versions
 
 When modifying an existing feature under `features/src/<feature>/`, increment the patch component of that feature's `devcontainer-feature.json` version in the same pull request. Increment it once per feature per pull request, regardless of how many files or commits modify the feature.
+
+Before selecting the new version, update the branch with `main` and increment from the version currently on `main`, not from the branch's original base.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,4 +4,4 @@
 
 When modifying an existing feature under `features/src/<feature>/`, increment the patch component of that feature's `devcontainer-feature.json` version in the same pull request. Increment it once per feature per pull request, regardless of how many files or commits modify the feature.
 
-Before selecting the new version, update the branch with `main` and increment from the version currently on `main`, not from the branch's original base.
+Before selecting the new version, bring the working branch up to date with the pull request's target branch (for example, `main` or `release/*`) and increment from the version currently on that target branch, not from the working branch's original base.


### PR DESCRIPTION
Add repository-level agent instructions requiring each modified existing feature to increment its patch version in the same pull request.

This is an always-on rule rather than an optional skill so agents apply it to every feature change.
