### PR TITLE
Bump rapids-build-utils version for ghcr publication

### DIFF
--- a/features/src/llvm/devcontainer-feature.json
+++ b/features/src/llvm/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "LLVM compilers and tools",
   "id": "llvm",
-  "version": "26.10.0",
+  "version": "26.10.1",
   "description": "A feature to install LLVM compilers and tools",
   "options": {
     "version": {

--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "26.10.0",
+  "version": "26.10.1",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"

--- a/features/src/rapids-build-utils/devcontainer-feature.json
+++ b/features/src/rapids-build-utils/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "NVIDIA RAPIDS devcontainer build utilities",
   "id": "rapids-build-utils",
-  "version": "26.10.1",
+  "version": "26.10.6",
   "description": "A feature to install the RAPIDS devcontainer build utilities",
   "containerEnv": {
     "BASH_ENV": "/etc/bash.bash_env"


### PR DESCRIPTION
#766 did not include the necessary bump